### PR TITLE
Revert "Fix #4: Build failure with master version of math-comp."

### DIFF
--- a/theories/PFsection3.v
+++ b/theories/PFsection3.v
@@ -577,7 +577,7 @@ Arguments sat_cases [m th] k [cl].
 
 Definition unsat_cases_hyp th0 kvs tO cl :=
   let: (k, _) := head (2, 0) kvs in let thk_ := ext_cl th0 cl k in
-  let th's := [seq unwrap (thk_ v) | v <- lit_vals & (v \notin unzip2 kvs)] in
+  let th's := [seq unwrap (thk_ v) | v <- lit_vals & v \notin unzip2 kvs] in
   let add hyp kv :=
     let: (_, v) := kv in let: Wrap th := thk_ v in hyp /\ unsat th in
   foldl add (wf_ext_cl cl k (th_dim th0) && all (predC tO) th's) kvs.


### PR DESCRIPTION
Reverts math-comp/odd-order#5
(merge https://github.com/math-comp/math-comp/pull/236 first)