### PR TITLE
Adapt to `seq` permutation lemmas renamings

### DIFF
--- a/theories/BGsection3.v
+++ b/theories/BGsection3.v
@@ -538,8 +538,8 @@ have irrK'K: mx_absolutely_irreducible rK'K.
     exact: joing_subl.
   have eq_sK': #|[set: sK'K]| = #|[set: sK'G']|.
     rewrite !cardsT !cardE -!(size_map (fun i => socle_val i)).
-    apply: perm_eq_size.
-    rewrite uniq_perm_eq 1?(map_inj_uniq val_inj) 1?enum_uniq // => V.
+    apply: perm_size.
+    rewrite uniq_perm 1?(map_inj_uniq val_inj) 1?enum_uniq // => V.
     apply/mapP/mapP=> [] [i _ ->{V}].
       exists (PackSocle (component_socle sK'G' (socle_simple i))).
         by rewrite mem_enum.

--- a/theories/PFsection10.v
+++ b/theories/PFsection10.v
@@ -1022,7 +1022,7 @@ have{lt1d} [defS szS1 Dd Ddel Dn]:
   rewrite natrD addrK eqxx => /andP[/eqP Dd /nilP S3nil].
   have uS12: uniq (S1 ++ S2).
     by rewrite cat_uniq seqInd_uniq uS2 andbT; apply/hasPn.
-  rewrite uniq_perm_eq ?seqInd_uniq {uS12}// => [|xi]; last first.
+  rewrite uniq_perm ?seqInd_uniq {uS12}// => [|xi]; last first.
     apply/idP/idP; apply: allP xi; last by rewrite all_cat !(introT allP _).
     by rewrite -(canLR negbK (has_predC _ _)) has_filter -/S3 S3nil.
   have: (w1 %| d%:R - delta)%C.
@@ -1041,7 +1041,7 @@ have [tau1 cohS1]: coherent S1 M^# tau.
 have [[Itau1 Ztau1] Dtau1] := cohS1.
 have o1S1tau: orthonormal (map tau1 S1) by apply: map_orthonormal.
 have S1zeta: zeta \in S1.
-  by have:= Szeta; rewrite (perm_eq_mem defS) mem_cat => /orP[//|/redS2/negP].
+  by have:= Szeta; rewrite (perm_mem defS) mem_cat => /orP[//|/redS2/negP].
 (* This is the main part of step 10.10.3; as the definition of alpha_ remains *)
 (* valid we do not need to reprove alpha_on.                                  *)
 have Dalpha i (al_ij := alpha_ i j) :
@@ -1136,7 +1136,7 @@ case=> _ _ ccS2 _ _ [tau2 Dtau2 cohS2].
 have{cohS2} cohS2: coherent_with S2 M^# tau tau2 by apply: cohS2.
 have sS20: cfConjC_subset S2 calS0.
   by split=> // xi /sS2S Sxi; have [_ ->] := sSS0.
-rewrite perm_eq_sym perm_catC in defS; apply: perm_eq_coherent defS _.
+rewrite perm_sym perm_catC in defS; apply: perm_coherent defS _.
 suffices: (mu_ j - d%:R *: zeta)^\tau = tau2 (mu_ j) - tau1 (d%:R *: zeta).
   apply: (bridge_coherent scohS0 sS20 cohS2 sS10 cohS1) => [phi|].
     by apply: contraL => /S1'2.

--- a/theories/PFsection11.v
+++ b/theories/PFsection11.v
@@ -674,7 +674,7 @@ Let memSred : Sred =i Smu.
 Proof.
 have [szSred _ memSred _] := typeP_reducible_core_Ind maxM MtypeP notMtype5.
 have uSred: uniq Sred by apply: filter_uniq (seqInd_uniq _ _).
-suffices{uSred}: (size Smu <= size Sred)%N by case/leq_size_perm.
+suffices{uSred}: (size Smu <= size Sred)%N by case/uniq_min_size.
 by rewrite szSred def_p size_map -cardE cardC1 nirrW2.
 Qed.
 
@@ -949,8 +949,8 @@ without loss tau2muj: tau2 coh_tau2 / tau2 (mu_ j) = eta_col j; last first.
   case: FTtype34_noncoherence; rewrite H0_1 -joinGE join1G.
   have uS12: uniq (S2 ++ S1).
     by rewrite cat_uniq ?seqInd_uniq ?andbT //=; apply/hasPn.
-  have /perm_eq_coherent: perm_eq (S2 ++ S1) (S_ C); last apply.
-    apply: uniq_perm_eq; rewrite ?seqInd_uniq // => xi; rewrite mem_cat.
+  have /perm_coherent: perm_eq (S2 ++ S1) (S_ C); last apply.
+    apply: uniq_perm; rewrite ?seqInd_uniq // => xi; rewrite mem_cat.
     apply/idP/idP=> [/orP | /seqIndP[i /setDP[kCi k'HUi] ->]].
       by case; apply/seqIndS/Iirr_kerDS; rewrite ?joing_subr.
     by rewrite !mem_seqInd // inE orbC inE kCi k'HUi andbT orbN.

--- a/theories/PFsection13.v
+++ b/theories/PFsection13.v
@@ -490,7 +490,7 @@ pose calH1 := rem zeta1 (rem zeta0 (filter [mem calS1] calH)).
 pose calH2 := filter [predC calS1] calH.
 have DcalH: perm_eq calH (zeta0 :: zeta1 :: calH1 ++ calH2).
   rewrite -(perm_filterC [mem calS1]) -!cat_cons perm_cat2r.
-  rewrite (perm_eqlP (@perm_to_rem _ zeta0 _ _)) ?mem_filter /= ?S1zeta0 //.
+  rewrite (permPl (@perm_to_rem _ zeta0 _ _)) ?mem_filter /= ?S1zeta0 //.
   rewrite perm_cons perm_to_rem // mem_rem_uniq ?filter_uniq ?seqInd_uniq //.
   by rewrite !inE mem_filter /= eq_sym zeta1'0 S1zeta1 sS1H.
 have{DcalH} [a_ _ Dchi _] := invDade_seqInd_sum ddH chi DcalH.

--- a/theories/PFsection3.v
+++ b/theories/PFsection3.v
@@ -516,7 +516,7 @@ have [-> | [dk Ydk] _ /eqP sz_kvs] := set_0Vmem (dirr_constt Y).
   by rewrite big_set0 ltrr.
 have Dks: ks =i iota 0 (size m).
   have: {subset ks <= iota 0 (size m)} by move=> k /lt_ks; rewrite mem_iota.
-  by case/leq_size_perm=> //; rewrite size_iota size_map sz_kvs.
+  by case/uniq_min_size; rewrite // size_iota size_map sz_kvs.
 suffices o_dk_m: orthogonal (dchi dk) m.
   exists dk; rewrite // dirr_consttE defX cfdotDl cfdot_suml.
   rewrite big1_seq ?add0r -?dirr_consttE // => xi /sAm CFxi.
@@ -759,7 +759,7 @@ have SsP mi si ri (Ii := I_ si mi):
     move=> i; rewrite mem_cat mem_filter orb_andr orbN mem_iota.
     by apply: orb_idl => /ltsi/leq_trans->.
   split=> // [i|]; first by rewrite defIi mem_iota.
-  by rewrite (perm_eq_size (uniq_perm_eq _ _ defIi)) ?size_iota.
+  by rewrite (perm_size (uniq_perm _ _ defIi)) ?size_iota.
 have lt_nth ri si i: (nth ri si i < ri)%N -> (i < size si)%N.
   by rewrite !ltnNge; apply: contra => le_si; rewrite nth_default.
 case: s => [si sj sk] /= sym12 Uth2 m m_th1; case/and3P: (m_th1) sym12.

--- a/theories/PFsection5.v
+++ b/theories/PFsection5.v
@@ -528,10 +528,10 @@ move=> /zchar_subset sS12 [Itau1 Dtau1].
 by split=> [|xi /sS12/Dtau1//]; apply: sub_iso_to Itau1.
 Qed.
 
-Lemma perm_eq_coherent S1 S2 A tau:
+Lemma perm_coherent S1 S2 A tau:
   perm_eq S1 S2 -> coherent S1 A tau -> coherent S2 A tau.
 Proof.
-by move=> eqS12; apply: subset_coherent => phi; rewrite (perm_eq_mem eqS12).
+by move=> eqS12; apply: subset_coherent => phi; rewrite (perm_mem eqS12).
 Qed.
 
 Lemma dual_coherence S tau R nu :
@@ -604,7 +604,7 @@ have{S'0} nzd: d != 0 by rewrite char1_eq0 ?N_S ?(memPn S'0).
 pose S1 := eta1 :: [seq eta - eta1 *+ a eta | eta <- rem eta1 S].
 have sS_ZS1: {subset S <= 'Z[S1]}; last apply: (subgen_coherent sS_ZS1).
   have Zeta1: eta1 \in 'Z[S1] by rewrite mem_zchar ?mem_head.
-  apply/allP; rewrite (eq_all_r (perm_eq_mem (perm_to_rem Seta1))) /= Zeta1.
+  apply/allP; rewrite (eq_all_r (perm_mem (perm_to_rem Seta1))) /= Zeta1.
   apply/allP=> eta Seta; rewrite -(rpredBr eta (rpredMn (a eta) Zeta1)).
   exact/mem_zchar/mem_behead/map_f.
 have{sS_ZS1} freeS1: free S1.
@@ -1096,7 +1096,7 @@ have oS2: pairwise_orthogonal S2 by have [] := subset_subcoherent sS20.
 have nz_chi: chi != 0 by rewrite eq_sym; have [/norP[]] := andP oS2.
 have o_chi_chic: '[chi, chi^*] = 0 by have [_ /andP[/andP[/eqP]]] := and3P oS2.
 have def_XXc: X - Xc = tau (chi - chi^*%CF).
-  by rewrite opprK defX -big_cat sumR; apply: eq_big_perm.
+  by rewrite opprK defX -big_cat sumR; apply: perm_big.
 have oXXc: '[X, Xc] = 0.
   have /span_orthogonal o_e_ec: orthogonal e ec.
     by move: o1R; rewrite -(eq_orthonormal defR) orthonormal_cat => /and3P[].
@@ -1338,7 +1338,7 @@ have eqRchi: perm_eq (R chi1) (E ++ Ec).
   exact/free_uniq/orthonormal_free.
 have /and3P[oE _ oEEc]: [&& orthonormal E, orthonormal Ec & orthogonal E Ec].
   by rewrite (eq_orthonormal eqRchi) orthonormal_cat in oRchi.
-rewrite defRchi (eq_big_perm _ eqRchi) big_cat -defX cfdotDr nX defX !big_seq.
+rewrite defRchi (perm_big _ eqRchi) big_cat -defX cfdotDr nX defX !big_seq.
 by rewrite (span_orthogonal oEEc) ?addr0 ?rpred_sum //; apply: memv_span.
 Qed.
 

--- a/theories/PFsection6.v
+++ b/theories/PFsection6.v
@@ -296,12 +296,12 @@ have: perm_eq (Y ++ [::]) calX by rewrite cats0.
 have: {in Y & [::], forall xi1 xi2, d xi1 <= d xi2}%N by [].
 elim: {Y}_.+1 {-2}Y [::] (ltnSn (size Y)) => // m IHm Y X' leYm leYX' defX ccY.
 have sYX: {subset Y <= calX}.
-  by move=> xi Yxi; rewrite -(perm_eq_mem defX) mem_cat Yxi.
+  by move=> xi Yxi; rewrite -(perm_mem defX) mem_cat Yxi.
 have sX'X: {subset X' <= calX}.
-  by move=> xi X'xi; rewrite -(perm_eq_mem defX) mem_cat X'xi orbT.
+  by move=> xi X'xi; rewrite -(perm_mem defX) mem_cat X'xi orbT.
 have uniqY: uniq Y.
   have: uniq calX := seqInd_uniq L _.
-  by rewrite -(perm_eq_uniq defX) cat_uniq => /and3P[].
+  by rewrite -(perm_uniq defX) cat_uniq => /and3P[].
 have sYS: {subset Y <= calS} by move=> xi /sYX/seqInd_sub->.
 case homoY: (constant [seq xi 1%g | xi : 'CF(L) <- Y]).
   exact: uniform_degree_coherence (subset_subcoherent scohS _) homoY.
@@ -325,9 +325,9 @@ have ccY': cfConjC_closed Y'.
   move=> xi; rewrite !(inE, mem_rem_uniq) ?rem_uniq //.
   by rewrite !(inv_eq (@cfConjCK _ _)) cfConjCK => /and3P[-> -> /ccY->].
 have Xchi := sYX _ Ychi; have defY: perm_eq [:: chi, chi^*%CF & Y'] Y.
-  rewrite (perm_eqrP (perm_to_rem Ychi)) perm_cons perm_eq_sym perm_to_rem //.
+  rewrite (permPr (perm_to_rem Ychi)) perm_cons perm_sym perm_to_rem //.
   by rewrite mem_rem_uniq ?inE ?ccY // (seqInd_conjC_neq _ _ _ Xchi).
-apply: perm_eq_coherent (defY) _.
+apply: perm_coherent (defY) _.
 have d_chic: d chi^*%CF = d chi.
   by rewrite /d cfunE conj_Cnat // (Cnat_seqInd1 Xchi).
 have /and3P[uniqY' Y'xi1 notY'chi]: [&& uniq Y', xi1 \in Y' & chi \notin Y'].
@@ -337,12 +337,12 @@ have sY'Y: {subset Y' <= Y} by move=> xi /mem_rem/mem_rem.
 have sccY'S: cfConjC_subset Y' calS by split=> // xi /sY'Y/sYS.
 apply: (extend_coherent scohS _ Y'xi1); rewrite ?sYS {sccY'S notY'chi}//.
 have{defX} defX: perm_eq (Y' ++ X'') calX.
-  by rewrite (perm_catCA Y' [::_; _]) catA -(perm_eqrP defX) perm_cat2r.
+  by rewrite (perm_catCA Y' [::_; _]) catA -(permPr defX) perm_cat2r.
 have{d_chic} le_chi_X'': {in X'', forall xi, d chi <= d xi}%N.
   by move=> xi /or3P[/eqP-> | /eqP-> | /leYX'->] //; rewrite d_chic.
 rewrite !Ndg ?sYX // dvdC_nat dvdn_pmul2l // dvdn_exp2l 1?ltnW //; split=> //.
   apply: IHm defX ccY' => [|xi xi' /sY'Y/leYchi-le_xi_chi /le_chi_X''].
-    by rewrite -ltnS // (leq_trans _ leYm) // -(perm_eq_size defY) ltnW.
+    by rewrite -ltnS // (leq_trans _ leYm) // -(perm_size defY) ltnW.
   exact: leq_trans.
 have p_gt0 n: (0 < p ^ n)%N by rewrite expn_gt0 prime_gt0.
 rewrite -!natrM; apply: (@ltr_le_trans _ (e ^ 2 * (p ^ d chi) ^ 2)%:R).
@@ -373,7 +373,7 @@ rewrite -expnM Gauss_dvd ?coprime_expl ?coprime_expr {coep}// dvdn_mulr //=.
 have /dvdn_addl <-: p ^ (d chi * 2) %| e ^ 2 * sum_p2d X''.
   rewrite big_distrr big_seq dvdn_sum //= => xi /le_chi_X'' le_chi_xi.
   by rewrite dvdn_mull // dvdn_exp2l ?leq_pmul2r.
-rewrite -mulnDr -big_cat (eq_big_perm _ defX) -(natCK (e ^ 2 * _)) /=.
+rewrite -mulnDr -big_cat (perm_big _ defX) -(natCK (e ^ 2 * _)) /=.
 rewrite -def_sum_xi1 // /sum_xi1 sum_seqIndD_square ?normal1 ?sub1G //.
 rewrite indexg1 -(natrB _ (cardG_gt0 Z)) -natrM natCK.
 rewrite -(Lagrange_index sKL sZK) mulnAC dvdn_mull //.
@@ -835,9 +835,9 @@ have{odd_frobL1} caseA_cohXY: caseA -> coherent (X ++ Y) L^# tau.
       by rewrite linearZ mod_IirrE // cfMod1.
     transitivity (\sum_(xi <- X) xi 1%g *: xi).
       by apply: eq_big_seq => xi Xxi; rewrite scalerA mulrC -def_d.
-    rewrite (eq_big_perm [seq 'chi_i | i in [predC kerZ]]).
+    rewrite (perm_big [seq 'chi_i | i in [predC kerZ]]).
       by rewrite big_map big_filter.
-    apply: uniq_perm_eq => // [|xi].
+    apply: uniq_perm => // [|xi].
       by rewrite (map_inj_uniq irr_inj) ?enum_uniq.
     rewrite defX; apply/andP/imageP=> [[/irrP[i ->]] | [i]]; first by exists i.
     by move=> kerZ'i ->; rewrite mem_irr.
@@ -892,8 +892,8 @@ have{odd_frobL1} caseA_cohXY: caseA -> coherent (X ++ Y) L^# tau.
     have defY: perm_eq Y (eta1 :: eta1^*)%CF.
       have uYeta: uniq (eta1 :: eta1^*)%CF.
         by rewrite /= inE eq_sym (hasPn nrS) ?sYS.
-      rewrite perm_eq_sym uniq_perm_eq //.
-      have [|//]:= leq_size_perm uYeta _ szY2.
+      rewrite perm_sym uniq_perm //.
+      have [|//]:= uniq_min_size uYeta _ szY2.
       by apply/allP; rewrite /= Yeta1 ccY.
     have memYtau1c: {subset [seq tau1 eta^* | eta <- Y]%CF <= map tau1 Y}.
       by move=> _ /mapP[eta Yeta ->]; rewrite /= map_f ?ccY.
@@ -902,7 +902,7 @@ have{odd_frobL1} caseA_cohXY: caseA -> coherent (X ++ Y) L^# tau.
       by apply/orthogonalP=> phi psi ? /memYtau1c; apply: (orthogonalP o_tauXY).
     - rewrite (map_comp -%R) orthogonal_oppr.
       by apply/orthoPl=> psi /memYtau1c; apply: (orthoPl oX1tauY).
-    rewrite tau_psi1 (eq_big_perm _ defY) Db q1 /= mul1r big_cons big_seq1.
+    rewrite tau_psi1 (perm_big _ defY) Db q1 /= mul1r big_cons big_seq1.
     by rewrite scalerDr addrA subrK -scalerN opprK.
   have [[Itau1 Ztau1] Dtau1] := cohY.
   have n1X1: '[X1] = 1.
@@ -1069,7 +1069,7 @@ have{caseA_cohXY Itau1 Ztau1 Dtau1 oYYt} cohXY: coherent (X ++ Y) L^# tau.
         rewrite rem_filter // !big_filter; apply/eq_bigr => eta /negPf->.
         by rewrite subr0 Cint_normK.
       rewrite big_const_seq count_predT // -Monoid.iteropE -[LHS]mulr_natl.
-      by rewrite /m (perm_eq_size (perm_to_rem Yeta1)) /= mulrSr addrK.
+      by rewrite /m (perm_size (perm_to_rem Yeta1)) /= mulrSr addrK.
     have [x_eq0 | [x_eq1 szY2]] := m_ub2_lt2 x Zx ub_xm.
       left; rewrite /Y1 x_eq0 (big_rem eta1) //= eqxx sub0r scaleN1r.
       rewrite big_seq big1 ?addr0 ?opprK => // eta.
@@ -1077,11 +1077,11 @@ have{caseA_cohXY Itau1 Ztau1 Dtau1 oYYt} cohXY: coherent (X ++ Y) L^# tau.
     have eta1'2: eta1^*%CF != eta1 by apply: seqInd_conjC_neq Yeta1.
     have defY: perm_eq Y (eta1 :: eta1^*%CF).
       have uY2: uniq (eta1 :: eta1^*%CF) by rewrite /= inE eq_sym eta1'2.
-      rewrite perm_eq_sym uniq_perm_eq //.
+      rewrite perm_sym uniq_perm //.
       have sY2Y: {subset (eta1 :: eta1^*%CF) <= Y}.
         by apply/allP; rewrite /= cfAut_seqInd ?Yeta1.
-      by have [|//]:= leq_size_perm uY2 sY2Y; rewrite szY2.
-    right; split=> //; congr (- _); rewrite (eq_big_perm _ defY) /= x_eq1.
+      by have [|//]:= uniq_min_size uY2 sY2Y; rewrite szY2.
+    right; split=> //; congr (- _); rewrite (perm_big _ defY) /= x_eq1.
     rewrite big_cons big_seq1 eqxx (negPf eta1'2) subrr scale0r add0r subr0.
     by rewrite scale1r.
   have normY1: '[Y1] = 1.
@@ -1271,8 +1271,8 @@ have{caseA_cohXY Itau1 Ztau1 Dtau1 oYYt} cohXY: coherent (X ++ Y) L^# tau.
   pose Y2 := eta1 :: eta1^*%CF; suffices: xi \in Y2.
     rewrite opprK !inE (negPf eta1'xi) /= => /eqP->.
     by rewrite !oYY ?ccY // !mulrb eqxx ifN_eqC ?(hasPn nrS) ?sYS ?addr0.
-  have /leq_size_perm: {subset Y2 <= Y} by apply/allP; rewrite /= Yeta1 ccY.
-  by case=> [||->]; rewrite ?szY2 //= inE eq_sym (hasPn nrS) ?sYS.
+  have /uniq_min_size: {subset Y2 <= Y} by apply/allP; rewrite /= Yeta1 ccY.
+  by case=> [||_ ->]; rewrite ?szY2 //= inE eq_sym (hasPn nrS) ?sYS.
 pose S1 := [::] ++ X ++ Y; set S2 := [::] in S1; rewrite -[X ++ Y]/S1 in cohXY.
 have ccsS1S: cfConjC_subset S1 S.
   rewrite /S1 /=; split; first by rewrite cat_uniq uX uY andbT; apply/hasPn.

--- a/theories/PFsection7.v
+++ b/theories/PFsection7.v
@@ -280,9 +280,9 @@ Variant is_invDade_seqInd_sum : Prop :=
 Lemma invDade_seqInd_sum : perm_eq calT (xi0 :: S) -> is_invDade_seqInd_sum.
 Proof.
 move=> defT; pose chi0 := \sum_(xi <- S) (c xi)^* / '[xi] *: xi.
-have Txi0: xi0 \in calT by rewrite (perm_eq_mem defT) mem_head.
+have Txi0: xi0 \in calT by rewrite (perm_mem defT) mem_head.
 have sST : {subset S <= calT}.
-  by move=> xi Sxi; rewrite (perm_eq_mem defT) mem_behead.
+  by move=> xi Sxi; rewrite (perm_mem defT) mem_behead.
 have nz_xi01 : xi0 1%g != 0 by apply: seqInd1_neq0 Txi0.
 have part_a: {in A, chi^\rho =1 chi0}.
   pose phi := (chi^\rho - chi0) * '1_A.
@@ -304,7 +304,7 @@ have part_a: {in A, chi^\rho =1 chi0}.
     by apply/seqIndP; exists i; rewrite ?inE.
   have{Tphi} [z def_phi _] := free_span (seqInd_free nsHL _) Tphi.
   have {phi def_phi phi1} ->: phi = \sum_(xi <- S) z xi *: psi xi.
-    rewrite def_phi (eq_big_perm _ defT) !big_cons /= 2!cfunE in phi1 *.
+    rewrite def_phi (perm_big _ defT) !big_cons /= 2!cfunE in phi1 *.
     rewrite (canRL (mulfK nz_xi01) (canRL (addrK _) phi1)) add0r addrC mulNr.
     rewrite sum_cfunE mulr_suml scaleNr scaler_suml -sumrB.
     by apply: eq_bigr => xi _; rewrite cfunE -mulrA -scalerA -scalerBr.
@@ -364,8 +364,8 @@ have defZS: 'Z[calS, L^#] =i 'Z[calS, A] by apply: zcharD1_seqInd.
 have S1P xi: xi \in S1 -> xi != zeta /\ xi \in calS.
   by rewrite mem_rem_uniq // => /andP[].
 have defT: perm_eql calT [:: Ind1H, zeta & S1].
-  apply/perm_eqlP; have Tind1: Ind1H \in calT := seqIndT_Ind1 H L.
-  by rewrite (perm_eqlP (perm_to_rem Tind1)) perm_cons -seqIndC1_rem.
+  apply/permPl; have Tind1: Ind1H \in calT := seqIndT_Ind1 H L.
+  by rewrite (permPl (perm_to_rem Tind1)) perm_cons -seqIndC1_rem.
 have mu_vchar: mu \in 'Z[irr L, A] := cfInd1_sub_lin_vchar nsHL Szeta zeta1.
 have beta_vchar: beta \in 'Z[irr G] by apply: Dade_vchar.
 have [mu_on beta_on] := (zchar_on mu_vchar, zchar_on beta_vchar).
@@ -411,7 +411,7 @@ have{def_a} def_a: {in calS, forall xi, a_ (nu xi) = '[beta, nu xi] / '[xi]}.
 pose a := '[beta, nu zeta] + 1; have Z1 := Cint1.
 have{Z1} Za: a \in Cint by rewrite rpredD ?Cint_cfdot_vchar // ZnuS.
 have {a_ def_a defX} defX: X = - nu zeta + a *: sumSnu.
-  rewrite linear_sum defX big_map !(eq_big_perm _ defS) !big_cons /= addrCA.
+  rewrite linear_sum defX big_map !(perm_big _ defS) !big_cons /= addrCA.
   rewrite def_a // Nzeta1 !divr1 zeta1 divff // scalerDl !scale1r addrA.
   rewrite addrK; congr (_ + _); apply: eq_big_seq => xi /S1P[neq_xi Sxi].
   rewrite def_a // scalerA mulrA mulrDl mul1r; congr (_ / _ *: _).

--- a/theories/PFsection9.v
+++ b/theories/PFsection9.v
@@ -809,7 +809,7 @@ have s_muC_mu: {subset filter redM (S_ H0C) <= mu_}.
   move=> phi; rewrite /= !mem_filter => /andP[->]; apply: seqIndS.
   by rewrite setSD // Iirr_kerS ?joing_subl.
 have UmuC: uniq (filter redM (S_ H0C)) by rewrite filter_uniq ?seqInd_uniq.
-have [|Dmu _] := leq_size_perm UmuC s_muC_mu; last first.
+have [|_ Dmu] := uniq_min_size UmuC s_muC_mu; last first.
   by split=> // phi; rewrite -Dmu mem_filter => /andP[].
 have [nsH0C_M _ _ _] := nsH0xx_M.
 have sCHU := subset_trans sCU sUHU; have sCM := subset_trans sCHU sHUM.
@@ -1052,7 +1052,7 @@ have sz_Smu: size Smu = p.-1.
   by rewrite size_map -cardE card_in_imset // cardC1 card_Iirr_abelian ?oH1.
 have [sz_mu s_mu_H0C] := nb_redM_H0.
 have Dmu: Smu =i mu_.
-  by have [|//] := leq_size_perm uSmu sSmu_mu; rewrite sz_mu sz_Smu.
+  by have [|//] := uniq_min_size uSmu sSmu_mu; rewrite sz_mu sz_Smu.
 split=> {Part_a part_a}//.
 - split=> // phi mu_phi; have S_HOC_phi := s_mu_H0C _ mu_phi.
   move: mu_phi; rewrite -Dmu => /imageP[_ /imsetP[i nz_i ->]].
@@ -1549,7 +1549,7 @@ suff [chi]: exists2 chi, chi \in S3 & coherent (chi :: chi^* :: S2)%CF M^# tau.
     apply/allP; rewrite /= !inE cfConjCK !eqxx orbT /=.
     by apply/allP=> psi /ccS2; rewrite !inE orbA orbC => ->.
   apply: leq_trans leS3nS; rewrite ltnNge; apply: contra S2'chi.
-  case/leq_size_perm=> [|psi|/(_ chi)]; first by rewrite filter_uniq.
+  case/uniq_min_size=> [|psi|_ /(_ chi)]; first by rewrite filter_uniq.
     by rewrite !mem_filter !inE orbA negb_or -andbA => /andP[].
   by rewrite !mem_filter !inE eqxx S0chi !andbT => /esym/negbFE.
 (* This is step (9.11.1). *) clear nS IHnS leS3nS.
@@ -1624,9 +1624,9 @@ without loss [[eqS12 irrS1 H0C_S1] [Da_p defC] [S3qu ne_qa_qu] [oS1 oS1ua]]:
   have lbS1'2: sumnS S1' <= sumnS S2 ?= iff ~~ has [predC S1'] S2.
     have Ds2: perm_eq S2 (S1' ++ filter [predC S1'] S2).
       rewrite -(perm_filterC (mem S1')) perm_cat2r.
-      rewrite uniq_perm_eq ?filter_uniq // => psi.
+      rewrite uniq_perm ?filter_uniq // => psi.
       by rewrite mem_filter andb_idr //= mem_filter => /andP[_ /sS12].
-    rewrite [sumnS S2](eq_big_perm _ Ds2) big_cat /= -/(sumnS S1') big_filter.
+    rewrite [sumnS S2](perm_big _ Ds2) big_cat /= -/(sumnS S1') big_filter.
     rewrite -all_predC -big_all_cond !(big_tnth _ _ S2) big_andE.
     rewrite -{1}[_ S1']addr0 mono_lerif; last exact: ler_add2l.
     set sumS2' := \sum_(i | _) _; rewrite -[0]/(sumS2' *+ 0) -sumrMnl.


### PR DESCRIPTION
Also rename `perm_eq_coherent` -> `perm_coherent` consistently with the
renaming rationale.