### PR TITLE
update wrt PR 473 of mathcomp

### DIFF
--- a/theories/BGappendixC.v
+++ b/theories/BGappendixC.v
@@ -139,7 +139,7 @@ Qed.
 Let odd_q : odd q.
 Proof.
 apply: contraR not_dvd_q_p1 => /prime_oddPn-> //.
-by rewrite -subn1 dvdn2 odd_sub ?odd_p.
+by rewrite -subn1 dvdn2 oddB ?odd_p.
 Qed.
 
 Let qgt2 : (2 < q)%N. Proof. by rewrite odd_prime_gt2. Qed.

--- a/theories/PFsection10.v
+++ b/theories/PFsection10.v
@@ -450,7 +450,7 @@ suffices: n ^+ 2 < n + 1.
   have{d_dv_M} d_odd: odd d by apply: dvdn_odd (mFT_odd M); rewrite -dvdC_nat.
   have: (2 %| n * w1%:R)%C.
     rewrite divfK ?neq0CG // -signrN signrE addrA -(natrD _ d 1).
-    by rewrite rpredB // dvdC_nat dvdn2 ?odd_double // odd_add d_odd.
+    by rewrite rpredB // dvdC_nat dvdn2 ?odd_double // oddD d_odd.
   rewrite -(truncCK Nn) -mulrSr -natrM -natrX ltC_nat (dvdC_nat 2) pnatr_eq0.
   rewrite dvdn2 odd_mul mFT_odd; case: (truncC n) => [|[|n1]] // _ /idPn[].
   by rewrite -leqNgt (ltn_exp2l 1).

--- a/theories/PFsection11.v
+++ b/theories/PFsection11.v
@@ -36,7 +36,7 @@ Import GroupScope Order.TTheory GRing.Theory FinRing.Theory Num.Theory.
 Section Eleven.
 
 (* This is Peterfalvi (11.1). *)
-Lemma lbound_expn_odd_prime p q : 
+Lemma lbound_expn_odd_prime p q :
    odd p -> odd q -> prime p -> prime q -> p != q -> 4 * q ^ 2 + 1 < p ^ q.
 Proof.
 move=> odd_p odd_q pr_p pr_q p_neq_q.
@@ -269,7 +269,7 @@ suffices /dvdnP[k Dk]: 2 * q %| #|HC : M^`(2)|.-1.
   apply: contraTeq ubHC; rewrite -leqNgt eqEsubset sM''_HC -indexg_gt1 addn1.
   by rewrite -[#|_:_|]prednK // {}Dk !ltnS muln_gt0 => /andP[/leq_pmull->].
 rewrite Gauss_dvd; last by rewrite coprime2n mFT_odd.
-rewrite dvdn2 -subn1 odd_sub // addbT negbK subn1.
+rewrite dvdn2 -subn1 oddB // addbT negbK subn1.
 rewrite -card_quotient; last by rewrite (subset_trans sHC_HU) // (der_norm 1).
 have Dq: q = #|W1 / M^`(2)|%g.
   apply/card_isog/quotient_isog; first by rewrite (subset_trans sW1M) ?gFnorm.

--- a/theories/PFsection12.v
+++ b/theories/PFsection12.v
@@ -72,7 +72,7 @@ Qed.
 Let mem_calI i : i \in calX -> 'chi_i \in calI.
 Proof. by move=> i_Iirr; apply/imageP; exists i. Qed.
 
-Lemma FTtype1_irrP i : 
+Lemma FTtype1_irrP i :
   reflect (exists2 chi, chi \in calS & i \in S_ chi) (i \in calX).
 Proof.
 have [sHL nHL] := andP nsHL; rewrite !inE sub1G andbT.
@@ -247,14 +247,14 @@ Local Notation Rgen := FTtype1_subcoherent.
 (* This is Peterfalvi (12.3) *)
 Lemma FTtype1_seqInd_ortho L1 L2 (maxL1 : L1 \in 'M) (maxL2 : L2 \in 'M)
     (L1type1 : FTtype L1 == 1%N) (L2type1 : FTtype L2 == 1%N)
-    (H1 := L1`_\F%G) (H2 := L2`_\F%G) 
-    (calS1 := seqIndD H1 L1 H1 1) (calS2 := seqIndD H2 L2 H2 1) 
-    (R1 := sval (Rgen maxL1 L1type1)) (R2 := sval (Rgen maxL2 L2type1)) : 
+    (H1 := L1`_\F%G) (H2 := L2`_\F%G)
+    (calS1 := seqIndD H1 L1 H1 1) (calS2 := seqIndD H2 L2 H2 1)
+    (R1 := sval (Rgen maxL1 L1type1)) (R2 := sval (Rgen maxL2 L2type1)) :
     gval L2 \notin L1 :^: G ->
   {in calS1 & calS2, forall chi1 chi2, orthogonal (R1 chi1) (R2 chi2)}.
 Proof.
 move=> notL1G_L2; without loss{notL1G_L2} disjointA1A:
-     L1 L2 maxL1 maxL2 L1type1 L2type1 @H1 @H2 @calS1 @calS2 @R1 @R2 / 
+     L1 L2 maxL1 maxL2 L1type1 L2type1 @H1 @H2 @calS1 @calS2 @R1 @R2 /
   [disjoint 'A1~(L2) & 'A~(L1)].
 - move=> IH_L; have [_ _] := FT_Dade_support_disjoint maxL1 maxL2 notL1G_L2.
   by case=> /IH_L-oS12 chi1 chi2 *; first rewrite orthogonal_sym; apply: oS12.
@@ -335,7 +335,7 @@ Let R := sval (Rgen maxL Ltype1).
 Let S_ (chi : 'CF(L)) := [set i in irr_constt chi].
 
 (* This is Peterfalvi (12.4). *)
-Lemma FTtype1_ortho_constant (psi : 'CF(G)) x : 
+Lemma FTtype1_ortho_constant (psi : 'CF(G)) x :
     {in calS, forall phi, orthogonal psi (R phi)} -> x \in L :\: H ->
   {in x *: H, forall y, psi y = psi x}%g.
 Proof.
@@ -351,7 +351,7 @@ have dot_irr xi j : xi \in calS -> j \in S_ xi -> '['chi_j, xi] = 1.
     by rewrite big_filter; have [] := FTtype1_seqInd_facts maxL Ltype1 xi_calS.
   rewrite (bigD1_seq j) ?mem_enum ?enum_uniq //= cfdotDr cfdot_sumr cfnorm_irr.
   by rewrite big1 ?addr0 // => k i'k; rewrite cfdot_irr eq_sym (negPf i'k).
-have {dot_irr} supp12B y xi j1 j2 : xi \in calS -> j1 \in S_ xi -> 
+have {dot_irr} supp12B y xi j1 j2 : xi \in calS -> j1 \in S_ xi ->
   j2 \in S_ xi ->  y \notin ('A(L) :\: H^#) -> ('chi_j1 - 'chi_j2) y = 0.
 - move=> calS_xi Sj1 Sj2 yADHn.
   have [xiD xi_cst sup_xi] := FTtype1_seqInd_facts maxL Ltype1 calS_xi.
@@ -425,7 +425,7 @@ by rewrite -subr_eq0 -cfdotBr (oResD xi) /S_ -?defA.
 Qed.
 
 (* This is Peterfalvi (12.5) *)
-Lemma FtypeI_invDade_ortho_constant (psi : 'CF(G)) : 
+Lemma FtypeI_invDade_ortho_constant (psi : 'CF(G)) :
     {in calS, forall phi, orthogonal psi (R phi)} ->
   {in H :\: H' &, forall x y, rho psi x = rho psi y}.
 Proof.
@@ -497,7 +497,7 @@ Qed.
 End Twelve_4_5.
 
 Hypothesis frobL : [Frobenius L with kernel H].
-  
+
 Lemma FT_Frobenius_type1 : FTtype L == 1%N.
 Proof.
 have [E /Frobenius_of_typeF LtypeF] := existsP frobL.
@@ -699,7 +699,7 @@ suffices [b dv_q_bp]: exists b : bool, q %| (b.*2 + p).-1.
   rewrite -ltn_double (@leq_ltn_trans (p + b.*2).-1) //; last first.
     by rewrite -!addnn -(subnKC pgt2) prednK // leq_add2l; case: (b).
   rewrite -(subnKC pgt2) dvdn_leq // -mul2n Gauss_dvd ?coprime2n // -{1}subn1.
-  by rewrite dvdn2 odd_sub // subnKC // odd_add odd_p odd_double addnC.
+  by rewrite dvdn2 oddB // subnKC // oddD odd_p odd_double addnC.
 have [// | [cHH rankH] | [/(_ p piHp)Udvp1 _]] := LtypeI; last first.
   exists false; apply: dvdn_trans Udvp1.
   by have:= piUq; rewrite mem_primes => /and3P[].
@@ -1020,7 +1020,7 @@ have ub_e: e%:R <= (p%:R + 1) / 2%:R :> algC.
     by have [_ /orP[]] := Ecyclic_le_p; [exists false | exists true].
   rewrite -ltnS (@leq_trans (b.*2 + p)) //; last first.
     by rewrite (leq_add2r p _ 2) (leq_double _ 1) leq_b1.
-  rewrite dvdn_double_ltn ?mFT_odd //; first by rewrite odd_add odd_double.
+  rewrite dvdn_double_ltn ?mFT_odd //; first by rewrite oddD odd_double.
   by rewrite -(subnKC pgt2) !addnS.
 have lb_h: p%:R ^+ 2 <= h%:R :> algC.
   rewrite -natrX leC_nat dvdn_leq ?pfactor_dvdn ?cardG_gt0 //.
@@ -1189,7 +1189,7 @@ have lb_psiM: '[rhoM psi] >= #|K :\: K'|%:R / #|M|%:R * e.-1%:R ^+ 2.
     by have [_ /orP[]] := Ecyclic_le_p; [exists false | exists true].
   apply: (@leq_trans (b.*2 + p)); last first.
     by rewrite (leq_add2r p _ 2) (leq_double b 1) leq_b1.
-  rewrite dvdn_double_ltn ?odd_add ?mFT_odd ?odd_double //.
+  rewrite dvdn_double_ltn ?oddD ?mFT_odd ?odd_double //.
   by rewrite addnC -(subnKC pgt2).
 have irrS: {subset calS <= irr L} by have [] := FT_Frobenius_coherence maxL.
 have lb_psiL: '[rhoL psi] >= 1 - e%:R / #|H|%:R.

--- a/theories/PFsection13.v
+++ b/theories/PFsection13.v
@@ -1283,7 +1283,7 @@ have regCW1: semiregular C W1.
   by move=> _ y /regUW1 regUx; rewrite setIAC regUx setI1g.
 have{regCW1} dv_2q_c1: q.*2 %| c.-1.
   rewrite -(subnKC c_gt1) -mul2n Gauss_dvd ?coprime2n ?dvdn2 ?mFT_odd //=.
-  rewrite odd_sub ?mFT_odd -?subSn // subn2 regular_norm_dvd_pred //.
+  rewrite oddB ?mFT_odd -?subSn // subn2 regular_norm_dvd_pred //.
   have /mulG_sub[_ sW1S] := sdprodW defS.
   apply: normsI; first by have [_ []] := StypeP.
   by rewrite (subset_trans sW1S) ?norms_cent ?gFnorm.
@@ -2129,7 +2129,7 @@ have{odd_bSphi_bLeta} xor_bS_bL: bS (+) bL.
   have:= eqCmod_trans odd_bSphi_bLeta (eqCmodD DbS DbL).
   rewrite -natrD eqCmod_sym -(eqCmodDr _ 1) -mulrSr => xor_bS_bL.
   have:= eqCmod_trans xor_bS_bL (eqCmodm0 _); rewrite /eqCmod subr0.
-  by rewrite (dvdC_nat 2 _.+1) dvdn2 /= negbK odd_add !oddb; case: (_ (+) _).
+  by rewrite (dvdC_nat 2 _.+1) dvdn2 /= negbK oddD !oddb; case: (_ (+) _).
 have ?: (0 != 1 %[mod 2])%C by rewrite eqCmod_sym /eqCmod subr0 (dvdC_nat 2 1).
 case is_c1: bS; [left | right].
   rewrite is_c1 in DbS; split=> //.

--- a/theories/PFsection14.v
+++ b/theories/PFsection14.v
@@ -574,7 +574,7 @@ have{a_gt1 a_dv_p1} defU1: U1 :=: [set: 'rV_2].
   rewrite cardsT card_matrix card_ord Zp_cast // leq_sqr -/p.
   apply: dvdn_leq; first by rewrite -(subnKC pgt2).
   rewrite -divn2 -(@Gauss_dvdl a _ 2) ?divnK //.
-    by rewrite dvdn2 -subn1 odd_sub ?odd_gt0 ?mFT_odd.
+    by rewrite dvdn2 -subn1 oddB ?odd_gt0 ?mFT_odd.
   by rewrite coprimen2 (dvdn_odd (dvdn_indexg U _)) ?mFT_odd.
 have [r pr_r r_r_U] := rank_witness U.
 have [R0 sylR0] := Sylow_exists r U; have [sR0U rR0 _] := and3P sylR0.
@@ -915,7 +915,7 @@ have{regKW2} [lb_k lb_k1e_v]: (2 * p * v < k /\ v.-1 %/ p < k.-1 %/ e)%N.
       by rewrite -(ltn_pmul2r (cardG_gt0 V)) -Dk mul1n proper_card.
     have x_gt0 := ltnW x_gt1; rewrite -(prednK x_gt0) ltnS -subn1.
     rewrite dvdn_leq ?subn_gt0 // -mul2n Gauss_dvd ?coprime2n ?mFT_odd //.
-    rewrite dvdn2 odd_sub // (dvdn_odd _ (mFT_odd K)) -/k ?Dk ?dvdn_mulr //=.
+    rewrite dvdn2 oddB // (dvdn_odd _ (mFT_odd K)) -/k ?Dk ?dvdn_mulr //=.
     rewrite -eqn_mod_dvd // -[x]muln1 -modnMmr.
     have nVW2: W2 \subset 'N(V) by have [_ []] := TtypeP.
     have /eqP{1} <-: (v == 1 %[mod p]).
@@ -1145,7 +1145,7 @@ have{n nmodq Dx} lb_x: (q + q.+1 * p <= x)%N.
   rewrite (divn_eq n q) nmodq (modn_small (ltnW qgt2)) addn1 in Dx.
   rewrite Dx leq_add2l leq_mul // ltnS leq_pmull // lt0n.
   have: odd x by rewrite (dvdn_odd (dvdn_indexg _ _)) ?mFT_odd.
-  by rewrite Dx odd_add odd_mul !mFT_odd; apply: contraNneq => ->.
+  by rewrite Dx oddD odd_mul !mFT_odd; apply: contraNneq => ->.
 have lb_h: (p ^ q < h)%N.
   rewrite (@leq_trans (p * nU)) //; last first.
     rewrite -DnU oH mulnA mulnC leq_mul // (leq_trans _ lb_x) //.

--- a/theories/PFsection3.v
+++ b/theories/PFsection3.v
@@ -1589,8 +1589,8 @@ by rewrite gt_eqF -?dirr_consttE.
 Qed.
 
 (* This is PeterFalvi (3.8). *)
-Lemma small_cycTI_NC phi i0 j0 (a0 := '[phi, eta_ i0 j0]) : 
-    {in V, forall x, phi x = 0} -> (NC phi < 2 * minn w1 w2)%N -> a0 != 0 ->    
+Lemma small_cycTI_NC phi i0 j0 (a0 := '[phi, eta_ i0 j0]) :
+    {in V, forall x, phi x = 0} -> (NC phi < 2 * minn w1 w2)%N -> a0 != 0 ->
      (forall i j, '[phi, eta_ i j] = (j == j0)%:R * a0)
   \/ (forall i j, '[phi, eta_ i j] = (i == i0)%:R * a0).
 Proof.
@@ -1600,7 +1600,7 @@ have{phiV_0} Da i2 j2 i1 j1 : a i1 j1 = a i1 j2 + a i2 j1 - a i2 j2.
   by rewrite cycTIiso_cfdot_exchange ?addrK.
 have ubA2: ~~ (w2 + w1 <= #|A| + 2)%N.
   rewrite addnC addn2 -ltnS (contra _ ubA) //; apply: (@leq_trans _ _.+3).
-  rewrite odd_geq /= ?odd_add ?oddW1 ?oddW2 // mul2n -addn_min_max -addnn.
+  rewrite odd_geq /= ?oddD ?oddW1 ?oddW2 // mul2n -addn_min_max -addnn.
   by rewrite uphalf_double leq_add2l gtn_min !leq_max !ltnn orbF -neq_ltn.
 (* This is step (3.8.1). *)
 have Za i1 i2 j1 j2 : a i1 j2 == 0 -> a i2 j1 == 0 -> a i1 j1 == 0.
@@ -1656,7 +1656,7 @@ by rewrite -oL0 lbA // => ij; rewrite !inE; apply/andP=> [[/eqP-> /idPn]].
 Qed.
 
 (* A weaker version of PeterFalvi (3.8). *)
-Lemma cycTI_NC_minn (phi : 'CF(G)) : 
+Lemma cycTI_NC_minn (phi : 'CF(G)) :
     {in V, forall x, phi x = 0} -> (0 < NC phi < 2 * minn w1 w2)%N ->
   (minn w1 w2 <= NC phi)%N.
 Proof.

--- a/theories/PFsection9.v
+++ b/theories/PFsection9.v
@@ -1082,7 +1082,7 @@ split=> {Part_a part_a}//.
     exists (theta f %% H0)%CF; first by rewrite cfMod_lin_char.
     by rewrite Ds  cfIirrE ?irrXtheta //= cfIndInd.
   suffices /(congr1 odd): u = (p.-1 ^ q.-1)%N.
-    rewrite odd_exp -(subnKC (prime_gt1 pr_q)) /= -subn1 odd_sub ?prime_gt0 //.
+    rewrite odd_exp -(subnKC (prime_gt1 pr_q)) /= -subn1 oddB ?prime_gt0 //.
     by rewrite -oH1 (oddSg sH1H) ?quotient_odd // mFT_odd.
   have p1_gt0: (0 < p.-1)%N by rewrite -(subnKC (prime_gt1 p_pr)).
   apply/eqP; rewrite -(eqn_pmul2r p1_gt0) -expnSr prednK ?prime_gt0 //.


### PR DESCRIPTION
`odd_add`, `odd_sub` have become `oddD`, `oddB` with mathcomp 1.11.0+beta1