### PR TITLE
Be robust to a change in the default argument naming algorithm.

### DIFF
--- a/theories/PFsection5.v
+++ b/theories/PFsection5.v
@@ -1606,4 +1606,4 @@ End DadeAut.
 End Five.
 
 Arguments coherent_prDade_TIred
-  [gT G H L K W W1 W2 S0 A A0 k tau1 defW].
+  [gT G H L K W W1 W2 S0 A A0 k tau1 defW] : rename.


### PR DESCRIPTION
Overlay for coq/coq#12756.
The argument which used to be named `S0` new gets name `S` by default.
This overlay preserves the old name, but it may be preferable to change to the name `S`.