### PR TITLE
remove warning implicite scope

### DIFF
--- a/theories/PFsection3.v
+++ b/theories/PFsection3.v
@@ -205,6 +205,7 @@ Notation x7 := +x7. Notation x8 := +x8.
 
 Definition AndLit kvs kv := kv :: kvs.
 Definition AddLit := AndLit.
+Declare Scope defclause_scope.
 Notation "(*dummy*)" := (Prop Prop) (at level 0) : defclause_scope.
 Arguments AddLit _%defclause_scope _.
 Infix "+" := AddLit : defclause_scope.

--- a/theories/PFsection7.v
+++ b/theories/PFsection7.v
@@ -337,6 +337,7 @@ Qed.
 
 End InvDadeSeqInd.
 
+Declare Scope classfun_scope.
 Notation "1" := (1 : 'CF(_)) : classfun_scope.
 
 (* This is Peterfalvi (7.8). *)


### PR DESCRIPTION
ok with mathcomp 1.12