### PR TITLE
Address deprecation warnings and clean up the import lists

### DIFF
--- a/theories/BGappendixAB.v
+++ b/theories/BGappendixAB.v
@@ -1,18 +1,13 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq div.
-From mathcomp
-Require Import fintype bigop prime finset ssralg fingroup morphism.
-From mathcomp
-Require Import automorphism quotient gfunctor commutator zmodp center pgroup.
-From mathcomp
-Require Import sylow gseries nilpotent abelian maximal.
-From mathcomp
-Require Import matrix mxalgebra mxrepresentation mxabelem.
-From odd_order
-Require Import BGsection1 BGsection2.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq div.
+From mathcomp Require Import fintype bigop prime finset.
+From mathcomp Require Import fingroup morphism automorphism quotient.
+From mathcomp Require Import ssralg zmodp matrix mxalgebra.
+From mathcomp Require Import center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal.
+From mathcomp Require Import mxrepresentation mxabelem.
+From odd_order Require Import BGsection1 BGsection2.
 
 (******************************************************************************)
 (* This file contains the useful material in B & G, appendices A and B, i.e., *)

--- a/theories/BGappendixC.v
+++ b/theories/BGappendixC.v
@@ -1,20 +1,17 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype choice ssrnat seq div fintype tuple finfun.
-From mathcomp
-Require Import bigop order ssralg finset prime binomial poly polydiv.
-From mathcomp
-Require Import fingroup morphism quotient automorphism action finalg zmodp.
-From mathcomp
-Require Import gfunctor gproduct cyclic commutator pgroup abelian frobenius.
-From odd_order
-Require Import BGsection1.
-From mathcomp
-Require Import matrix mxalgebra mxabelem vector falgebra fieldext galois.
-From mathcomp
-Require Import finfield ssrnum algC classfun character integral_char inertia.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq div.
+From mathcomp Require Import choice fintype tuple finfun bigop prime finset.
+From mathcomp Require Import binomial order.
+From mathcomp Require Import fingroup morphism automorphism quotient action.
+From mathcomp Require Import gproduct.
+From mathcomp Require Import ssralg finalg zmodp poly polydiv ssrnum matrix.
+From mathcomp Require Import mxalgebra vector.
+From mathcomp Require Import cyclic gfunctor commutator pgroup abelian.
+From mathcomp Require Import frobenius.
+From mathcomp Require Import falgebra fieldext galois algC finfield.
+From mathcomp Require Import mxabelem classfun character integral_char inertia.
+From odd_order Require Import BGsection1.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/theories/BGsection1.v
+++ b/theories/BGsection1.v
@@ -1,18 +1,13 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq path div fintype.
-From mathcomp
-Require Import bigop prime binomial finset fingroup morphism perm automorphism.
-From mathcomp
-Require Import quotient action gproduct gfunctor commutator.
-From mathcomp
-Require Import ssralg finalg zmodp cyclic center pgroup finmodule gseries.
-From mathcomp
-Require Import nilpotent sylow abelian maximal hall extremal.
-From mathcomp
-Require Import matrix mxalgebra mxrepresentation mxabelem.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div fintype bigop prime finset binomial.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct ssralg finalg zmodp matrix.
+From mathcomp Require Import mxalgebra.
+From mathcomp Require Import cyclic center gfunctor commutator finmodule.
+From mathcomp Require Import gseries pgroup nilpotent sylow abelian maximal.
+From mathcomp Require Import hall extremal mxrepresentation mxabelem.
 
 (******************************************************************************)
 (* This file contains most of the material in B & G, section 1, including the *)

--- a/theories/BGsection10.v
+++ b/theories/BGsection10.v
@@ -1,18 +1,13 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq div path fintype.
-From mathcomp
-Require Import bigop finset prime fingroup morphism perm automorphism quotient.
-From mathcomp
-Require Import action gproduct gfunctor pgroup cyclic center commutator.
-From mathcomp
-Require Import gseries nilpotent sylow abelian maximal hall.
-From odd_order
-Require Import BGsection1 BGsection3 BGsection4 BGsection5 BGsection6.
-From odd_order
-Require Import BGsection7 BGsection9.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div fintype bigop prime finset.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import cyclic center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal hall.
+From odd_order Require Import BGsection1 BGsection3 BGsection4 BGsection5.
+From odd_order Require Import BGsection6 BGsection7 BGsection9.
 
 (******************************************************************************)
 (*   This file covers B & G, section 10, including with the definitions:      *)

--- a/theories/BGsection11.v
+++ b/theories/BGsection11.v
@@ -1,18 +1,13 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq div path fintype.
-From mathcomp
-Require Import bigop finset prime fingroup morphism perm automorphism quotient.
-From mathcomp
-Require Import action gproduct gfunctor pgroup cyclic center commutator.
-From mathcomp
-Require Import gseries nilpotent sylow abelian maximal hall.
-From odd_order
-Require Import BGsection1 BGsection3 BGsection4 BGsection5 BGsection6.
-From odd_order
-Require Import BGsection7 BGsection10.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div fintype bigop prime finset.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import cyclic center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal hall.
+From odd_order Require Import BGsection1 BGsection3 BGsection4 BGsection5.
+From odd_order Require Import BGsection6 BGsection7 BGsection10.
 
 (******************************************************************************)
 (*   This file covers B & G, section 11; it has only one definition:          *)

--- a/theories/BGsection12.v
+++ b/theories/BGsection12.v
@@ -1,18 +1,14 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq choice div fintype.
-From mathcomp
-Require Import path bigop finset prime fingroup morphism perm automorphism.
-From mathcomp
-Require Import quotient action gproduct gfunctor pgroup cyclic commutator.
-From mathcomp
-Require Import center gseries nilpotent sylow abelian maximal hall frobenius.
-From odd_order
-Require Import BGsection1 BGsection3 BGsection4 BGsection5 BGsection6.
-From odd_order
-Require Import BGsection7 BGsection9 BGsection10 BGsection11.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div fintype bigop prime finset.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import cyclic center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal hall frobenius.
+From odd_order Require Import BGsection1 BGsection3 BGsection4 BGsection5.
+From odd_order Require Import BGsection6 BGsection7 BGsection9 BGsection10.
+From odd_order Require Import BGsection11.
 
 (******************************************************************************)
 (*   This file covers B & G, section 12; it defines the prime sets for the    *)

--- a/theories/BGsection13.v
+++ b/theories/BGsection13.v
@@ -1,18 +1,14 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq div path fintype.
-From mathcomp
-Require Import bigop finset prime fingroup morphism perm automorphism quotient.
-From mathcomp
-Require Import action gproduct gfunctor pgroup cyclic center commutator.
-From mathcomp
-Require Import gseries nilpotent sylow abelian maximal hall frobenius.
-From odd_order
-Require Import BGsection1 BGsection3 BGsection4 BGsection5 BGsection6.
-From odd_order
-Require Import BGsection7 BGsection9 BGsection10 BGsection12.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div fintype bigop prime finset.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import cyclic center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal hall frobenius.
+From odd_order Require Import BGsection1 BGsection3 BGsection4 BGsection5.
+From odd_order Require Import BGsection6 BGsection7 BGsection9 BGsection10.
+From odd_order Require Import BGsection12.
 
 (******************************************************************************)
 (*   This file covers B & G, section 13; the title subject of the section,    *)

--- a/theories/BGsection14.v
+++ b/theories/BGsection14.v
@@ -1,20 +1,14 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq div path fintype bigop order.
-From mathcomp
-Require Import finset prime fingroup morphism perm automorphism quotient.
-From mathcomp
-Require Import action gproduct gfunctor pgroup cyclic center commutator.
-From mathcomp
-Require Import gseries nilpotent sylow abelian maximal hall frobenius.
-From mathcomp
-Require Import ssralg ssrnum ssrint rat.
-From odd_order
-Require Import BGsection1 BGsection3 BGsection4 BGsection5 BGsection6.
-From odd_order
-Require Import BGsection7 BGsection9 BGsection10 BGsection12 BGsection13.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div fintype bigop prime finset order.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct ssralg ssrnum ssrint rat.
+From mathcomp Require Import cyclic center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal hall frobenius.
+From odd_order Require Import BGsection1 BGsection3 BGsection4 BGsection5.
+From odd_order Require Import BGsection6 BGsection7 BGsection9 BGsection10.
+From odd_order Require Import BGsection12 BGsection13.
 
 (******************************************************************************)
 (*   This file covers B & G, section 14, starting with the definition of the  *)

--- a/theories/BGsection15.v
+++ b/theories/BGsection15.v
@@ -1,20 +1,14 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq choice div fintype.
-From mathcomp
-Require Import path bigop finset prime fingroup morphism perm automorphism.
-From mathcomp
-Require Import quotient action gproduct gfunctor pgroup cyclic commutator.
-From mathcomp
-Require Import center gseries nilpotent sylow abelian maximal hall frobenius.
-From odd_order
-Require Import BGsection1 BGsection2 BGsection3 BGsection4 BGsection5.
-From odd_order
-Require Import BGsection6 BGsection7 BGsection9 BGsection10 BGsection12.
-From odd_order
-Require Import BGsection13 BGsection14.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div choice fintype bigop prime finset.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import cyclic center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal hall frobenius.
+From odd_order Require Import BGsection1 BGsection2 BGsection3 BGsection4.
+From odd_order Require Import BGsection5 BGsection6 BGsection7 BGsection9.
+From odd_order Require Import BGsection10 BGsection12 BGsection13 BGsection14.
 
 (******************************************************************************)
 (*   This file covers B & G, section 15; it fills in the picture of maximal   *)

--- a/theories/BGsection16.v
+++ b/theories/BGsection16.v
@@ -1,20 +1,15 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq div path fintype.
-From mathcomp
-Require Import bigop finset prime fingroup morphism perm automorphism quotient.
-From mathcomp
-Require Import action gproduct gfunctor pgroup cyclic center commutator.
-From mathcomp
-Require Import gseries nilpotent sylow abelian maximal hall frobenius.
-From odd_order
-Require Import BGsection1 BGsection2 BGsection3 BGsection4 BGsection5.
-From odd_order
-Require Import BGsection6 BGsection7 BGsection9 BGsection10 BGsection12.
-From odd_order
-Require Import BGsection13 BGsection14 BGsection15.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div fintype bigop prime finset.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import cyclic center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal hall frobenius.
+From odd_order Require Import BGsection1 BGsection2 BGsection3 BGsection4.
+From odd_order Require Import BGsection5 BGsection6 BGsection7 BGsection9.
+From odd_order Require Import BGsection10 BGsection12 BGsection13 BGsection14.
+From odd_order Require Import BGsection15.
 
 (******************************************************************************)
 (*   This file covers B & G, section 16; it summarises all the results of the *)

--- a/theories/BGsection2.v
+++ b/theories/BGsection2.v
@@ -1,22 +1,14 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq path div fintype.
-From mathcomp
-Require Import bigop prime binomial finset fingroup morphism perm automorphism.
-From mathcomp
-Require Import quotient action gfunctor commutator gproduct.
-From mathcomp
-Require Import ssralg finalg zmodp cyclic center pgroup gseries nilpotent.
-From mathcomp
-Require Import sylow abelian maximal hall.
-From mathcomp
-Require poly ssrint.
-From mathcomp
-Require Import matrix mxalgebra mxrepresentation mxabelem.
-From odd_order
-Require Import BGsection1.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div fintype bigop prime finset binomial.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct ssralg finalg zmodp ssrint poly.
+From mathcomp Require Import matrix mxalgebra.
+From mathcomp Require Import cyclic center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal.
+From mathcomp Require Import hall mxrepresentation mxabelem.
+From odd_order Require Import BGsection1.
 
 (******************************************************************************)
 (* This file covers the useful material in B & G, Section 2. This excludes    *)

--- a/theories/BGsection3.v
+++ b/theories/BGsection3.v
@@ -1,20 +1,14 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq path div.
-From mathcomp
-Require Import fintype tuple bigop prime binomial finset ssralg fingroup finalg.
-From mathcomp
-Require Import morphism perm automorphism quotient action commutator gproduct.
-From mathcomp
-Require Import zmodp cyclic gfunctor center pgroup gseries nilpotent sylow.
-From mathcomp
-Require Import finmodule abelian frobenius maximal extremal hall.
-From mathcomp
-Require Import matrix mxalgebra mxrepresentation mxabelem.
-From odd_order
-Require Import wielandt_fixpoint BGsection1 BGsection2.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div fintype tuple bigop prime finset binomial.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import ssralg finalg zmodp matrix mxalgebra.
+From mathcomp Require Import cyclic center gfunctor commutator finmodule.
+From mathcomp Require Import gseries pgroup nilpotent sylow abelian maximal.
+From mathcomp Require Import hall frobenius extremal mxrepresentation mxabelem.
+From odd_order Require Import wielandt_fixpoint BGsection1 BGsection2.
 
 (******************************************************************************)
 (*   This file covers the material in B & G, Section 3.                       *)

--- a/theories/BGsection4.v
+++ b/theories/BGsection4.v
@@ -1,20 +1,13 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq div.
-From mathcomp
-Require Import fintype finfun bigop ssralg finset prime binomial.
-From mathcomp
-Require Import fingroup morphism automorphism perm quotient action gproduct.
-From mathcomp
-Require Import gfunctor commutator zmodp cyclic center pgroup gseries nilpotent.
-From mathcomp
-Require Import sylow abelian maximal extremal hall.
-From mathcomp
-Require Import matrix mxalgebra mxrepresentation mxabelem.
-From odd_order
-Require Import BGsection1 BGsection2.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq div.
+From mathcomp Require Import fintype finfun bigop prime finset binomial.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct ssralg zmodp matrix mxalgebra.
+From mathcomp Require Import cyclic center gfunctor commutator.
+From mathcomp Require Import gseries pgroup nilpotent sylow abelian maximal.
+From mathcomp Require Import hall extremal mxrepresentation mxabelem.
+From odd_order Require Import BGsection1 BGsection2.
 
 (******************************************************************************)
 (*   This file covers B & G, Section 4, i.e., the proof of structure theorems *)

--- a/theories/BGsection5.v
+++ b/theories/BGsection5.v
@@ -1,16 +1,12 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq div.
-From mathcomp
-Require Import fintype finset prime fingroup morphism perm automorphism action.
-From mathcomp
-Require Import quotient cyclic gfunctor pgroup gproduct center commutator.
-From mathcomp
-Require Import gseries nilpotent sylow abelian maximal hall.
-From odd_order
-Require Import BGsection1 BGsection4.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq div.
+From mathcomp Require Import fintype prime finset.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import cyclic center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal hall.
+From odd_order Require Import BGsection1 BGsection4.
 
 (******************************************************************************)
 (*   This file covers Section 5 of B & G, except for some technical results   *)

--- a/theories/BGsection6.v
+++ b/theories/BGsection6.v
@@ -1,16 +1,11 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrfun ssrbool eqtype ssrnat seq div fintype finset.
-From mathcomp
-Require Import prime fingroup morphism automorphism quotient gproduct gfunctor.
-From mathcomp
-Require Import cyclic center commutator pgroup nilpotent sylow abelian hall.
-From mathcomp
-Require Import maximal.
-From odd_order
-Require Import BGsection1 BGappendixAB.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq div.
+From mathcomp Require Import fintype prime finset.
+From mathcomp Require Import fingroup morphism automorphism quotient gproduct.
+From mathcomp Require Import cyclic center gfunctor commutator.
+From mathcomp Require Import pgroup nilpotent sylow abelian maximal hall.
+From odd_order Require Import BGsection1 BGappendixAB.
 
 (******************************************************************************)
 (*   This file covers most of B & G section 6.                                *)

--- a/theories/BGsection7.v
+++ b/theories/BGsection7.v
@@ -1,17 +1,12 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq div choice fintype bigop.
-From mathcomp
-Require Import finset prime fingroup morphism automorphism action quotient.
-From mathcomp
-Require Import gfunctor cyclic pgroup center commutator gseries nilpotent.
-From mathcomp
-Require Import sylow abelian maximal hall.
-From odd_order
-Require Import BGsection1 BGsection6.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq div.
+From mathcomp Require Import choice fintype bigop prime finset.
+From mathcomp Require Import fingroup morphism automorphism quotient action.
+From mathcomp Require Import cyclic center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal hall.
+From odd_order Require Import BGsection1 BGsection6.
 
 (******************************************************************************)
 (*   This file covers B & G, section 7, i.e., the proof of the Thompson       *)

--- a/theories/BGsection8.v
+++ b/theories/BGsection8.v
@@ -1,14 +1,11 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq div fintype path.
-From mathcomp
-Require Import finset prime fingroup automorphism action gproduct gfunctor.
-From mathcomp
-Require Import center commutator pgroup gseries nilpotent sylow abelian maximal.
-From odd_order
-Require Import BGsection1 BGsection5 BGsection6 BGsection7.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div fintype prime finset.
+From mathcomp Require Import fingroup automorphism action gproduct.
+From mathcomp Require Import center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal.
+From odd_order Require Import BGsection1 BGsection5 BGsection6 BGsection7.
 
 (******************************************************************************)
 (*   This file covers B & G, section 8, i.e., the proof of two special cases  *)

--- a/theories/BGsection9.v
+++ b/theories/BGsection9.v
@@ -1,18 +1,12 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq div fintype path.
-From mathcomp
-Require Import finset prime fingroup action automorphism quotient cyclic.
-From mathcomp
-Require Import gproduct gfunctor pgroup center commutator gseries nilpotent.
-From mathcomp
-Require Import sylow abelian maximal hall.
-From odd_order
-Require Import BGsection1 BGsection4 BGsection5 BGsection6.
-From odd_order
-Require Import BGsection7 BGsection8.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div fintype prime finset.
+From mathcomp Require Import fingroup automorphism quotient action gproduct.
+From mathcomp Require Import cyclic center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal hall.
+From odd_order Require Import BGsection1 BGsection4 BGsection5 BGsection6.
+From odd_order Require Import BGsection7 BGsection8.
 
 (******************************************************************************)
 (*   This file covers B & G, section 9, i.e., the proof the Uniqueness        *)

--- a/theories/PFsection1.v
+++ b/theories/PFsection1.v
@@ -1,20 +1,16 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq path div choice fintype.
-From mathcomp
-Require Import tuple finfun bigop prime order ssralg finset fingroup morphism.
-From mathcomp
-Require Import perm automorphism quotient action zmodp finalg center commutator.
-From mathcomp
-Require Import poly cyclic pgroup nilpotent matrix mxalgebra mxrepresentation.
-From mathcomp
-Require Import vector falgebra fieldext ssrnum algC rat algnum galois.
-From mathcomp
-Require Import classfun character inertia integral_char vcharacter.
-From mathcomp
-Require ssrint.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div choice fintype tuple finfun bigop prime finset.
+From mathcomp Require Import order.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action.
+From mathcomp Require Import ssralg finalg zmodp poly ssrnum ssrint archimedean.
+From mathcomp Require Import rat matrix mxalgebra vector.
+From mathcomp Require Import cyclic center commutator pgroup nilpotent hall.
+From mathcomp Require Import falgebra fieldext galois algC algnum.
+From mathcomp Require Import mxrepresentation classfun character inertia.
+From mathcomp Require Import integral_char vcharacter.
 
 (******************************************************************************)
 (* This file covers Peterfalvi, Section 1: Preliminary results.               *)
@@ -177,10 +173,10 @@ move=> /= Hjk; wlog ->: eps n m / eps = false.
   by apply: IH; rewrite // -opprB cfdotNl (nm_ji, nm_ki) opprK.
 rewrite !cfdotBl !cfdotBr !cfdot_irr !opprB addrAC addrA.
 do 2!move/(canRL (subrK _)); rewrite -(natrD _ 1) -!natrD.
-move/(can_inj natCK); case: (m == i) => //.
+move/(can_inj natrK); case: (m == i) => //.
 case: eqP => // ->; case: (j == i) => // _.
 rewrite subr0 add0r => /(canRL (subrK _)); rewrite -(natrD _ 1).
-by move/(can_inj natCK); rewrite (negbTE Hjk).
+by move/(can_inj natrK); rewrite (negbTE Hjk).
 Qed.
 
 (* This is Peterfalvi (1.4). *)
@@ -476,7 +472,7 @@ Hypothesis abTbar : abelian (T / H).
 
 (* This is Peterfalvi (1.7)(b). *)
 Lemma cfInd_central_Inertia :
-   exists2 e, [/\ e \in Cnat, e != 0 & {in calA, forall t, e_ t = e}]
+   exists2 e, [/\ e \in Num.nat, e != 0 & {in calA, forall t, e_ t = e}]
            & [/\ 'Ind[G] theta = e *: \sum_(j in calB) 'chi_j,
                  #|calB|%:R = #|T : H|%:R / e ^+ 2
                & {in calB, forall i, 'chi_i 1%g = #|G : T|%:R * e * theta 1%g}].
@@ -484,11 +480,11 @@ Proof.
 have [t1 At1] := constt_cfInd_irr s sHT; pose psi1 := 'chi_t1.
 pose e := '['Ind theta, psi1].
 have NthT: 'Ind[T] theta \is a character by rewrite cfInd_char ?irr_char.
-have Ne: e \in Cnat by rewrite Cnat_cfdot_char_irr.
+have Ne: e \in Num.nat by rewrite Cnat_cfdot_char_irr.
 have Dpsi1H: 'Res[H] psi1 = e *: theta.
   have psi1Hs: s \in irr_constt ('Res psi1) by rewrite -constt_Ind_Res.
   rewrite (Clifford_Res_sum_cfclass nsHT psi1Hs) cfclass_invariant ?subsetIr //.
-  by rewrite big_seq1 cfdot_Res_l cfdotC conj_Cnat.
+  by rewrite big_seq1 cfdot_Res_l cfdotC conj_natr.
 have linL j: 'chi[T / H]_j \is a linear_char by apply/char_abelianP.
 have linLH j: ('chi_j %% H)%CF \is a linear_char := cfMod_lin_char (linL j).
 pose LtoT (j : Iirr (T / H)) := mul_mod_Iirr t1 j.
@@ -541,7 +537,7 @@ have ITtheta: T \subset 'I[theta] := subsetIr _ _.
 have solT: solvable (T / H) := abelian_sol abTbar.
 have [|t []] := extend_solvable_coprime_irr nsHT solT ITtheta; last by exists t.
 rewrite coprime_sym coprimeMl !(coprime_dvdl _ hallH) ?cfDet_order_dvdG //.
-by rewrite -dvdC_nat !CdivE truncCK ?Cnat_irr1 // dvd_irr1_cardG.
+by rewrite -dvdC_nat !CdivE truncK ?Cnat_irr1 // dvd_irr1_cardG.
 Qed.
   
 End IndSumInertia.
@@ -630,7 +626,7 @@ Lemma dvd_restrict_cfAut a (v : {rmorphism algC -> algC}) :
 Proof.
 have [-> | a_gt0] := posnP a.
   exists v => // chi x Zchi; rewrite /coprime gcdn0 order_eq1 => /eqP->.
-  by rewrite aut_Cint ?Cint_vchar1.
+  by rewrite aut_intr ?Cint_vchar1.
 pose b := (#|G|`_(\pi(a)^'))%N.
 have co_a_b: coprime a b := pnat_coprime (pnat_pi a_gt0) (part_pnat _ _).
 have [Qa _ [QaC _ [w_a genQa memQa]]] := group_num_field_exists [group of Zp a].
@@ -680,12 +676,11 @@ have [sXG0 | G0'x] := boolP (<[x]> \subset G0); last first.
 rewrite -!(cfResE chi sXG0) ?cycle_id ?mem_cycle //.
 rewrite ['Res _]cfun_sum_cfdot !sum_cfunE rmorph_sum; apply: eq_bigr => i _.
 have chiX := lin_charX (char_abelianP _ (cycle_abelian x) i) _ (cycle_id x).
-rewrite !cfunE/= rmorphM/= aut_Cnat ?Cnat_cfdot_char_irr ?cfRes_char //.
+rewrite !cfunE/= rmorphM/= aut_natr ?Cnat_cfdot_char_irr ?cfRes_char //.
 by congr (_ * _); rewrite Dv -chiX // -expg_mod_order (eqnP a_x) chiX.
 Qed.
 
 Section ANT.
-Import ssrint.
 
 (* This section covers Peterfalvi (1.10). *)
 (* We have simplified the statement somewhat by substituting the global ring  *)
@@ -710,7 +705,7 @@ suffices{chi Zchi} IHiX i: ('chi[X]_i (x * y)%g == 'chi_i y %[mod e])%A.
   have irr_free := (free_uniq (basis_free (irr_basis X))).
   have [c Zc ->] := (zchar_expansion irr_free (cfRes_vchar X Zchi)).
   rewrite !sum_cfunE /eqAmod -sumrB big_seq rpred_sum // => _  /irrP[i ->].
-  by rewrite !cfunE [(_ %| _)%A]eqAmodMl // rpred_Cint.
+  by rewrite !cfunE [(_ %| _)%A]eqAmodMl // rpred_int_num.
 have lin_chi: 'chi_i \is a linear_char.
   apply/char_abelianP; rewrite -[gval X]joing_idl -joing_idr abelianY.
   by rewrite !cycle_abelian cycle_subG /= cent_cycle.
@@ -724,14 +719,14 @@ Qed.
 
 (* This is Peterfalvi (1.10)(b); the primality condition is only needed here. *)
 Lemma int_eqAmod_prime_prim n :
-  prime p -> n \in Cint -> (n == 0 %[mod e])%A -> (p %| n)%C.
+  prime p -> n \in Num.int -> (n == 0 %[mod e])%A -> (p %| n)%C.
 Proof.
 move=> p_pr Zn; rewrite /eqAmod unfold_in subr0.
 have p_gt0 := prime_gt0 p_pr.
 case: ifPn => [_ /eqP->// | nz_e e_dv_n].
 suffices: (n ^+ p.-1 == 0 %[mod p])%A.
-  rewrite eqAmod0_rat ?rpredX ?rpred_nat 1?rpred_Cint // !dvdC_int ?rpredX //.
-  by rewrite floorCX // abszX Euclid_dvdX // => /andP[].
+  rewrite eqAmod0_rat ?rpredX ?rpred_nat 1?rpred_int_num ?dvdC_int ?rpredX //.
+  by rewrite floorX // abszX Euclid_dvdX // => /andP[].
 rewrite /eqAmod subr0 unfold_in pnatr_eq0 eqn0Ngt p_gt0 /=.
 pose F := \prod_(1 <= i < p) ('X - (eps ^+ i)%:P).
 have defF: F = \sum_(i < p) 'X^i.
@@ -756,5 +751,3 @@ Qed.
 End ANT.
 
 End Main.
-
-

--- a/theories/PFsection10.v
+++ b/theories/PFsection10.v
@@ -1,26 +1,21 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq path div choice fintype.
-From mathcomp
-Require Import tuple finfun bigop order prime ssralg poly finset center.
-From mathcomp
-Require Import fingroup morphism perm automorphism quotient action finalg zmodp.
-From mathcomp
-Require Import gfunctor gproduct cyclic commutator gseries nilpotent pgroup.
-From mathcomp
-Require Import sylow hall abelian maximal frobenius.
-From mathcomp
-Require Import matrix mxalgebra mxrepresentation mxabelem vector.
-From odd_order
-Require Import BGsection1 BGsection3 BGsection7 BGsection15 BGsection16.
-From mathcomp
-Require Import ssrnum algC classfun character integral_char inertia vcharacter.
-From odd_order
-Require Import PFsection1 PFsection2 PFsection3 PFsection4.
-From odd_order
-Require Import PFsection5 PFsection6 PFsection7 PFsection8 PFsection9.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div choice fintype tuple finfun bigop prime finset.
+From mathcomp Require Import order.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import ssralg finalg zmodp poly ssrnum archimedean matrix.
+From mathcomp Require Import mxalgebra vector.
+From mathcomp Require Import cyclic center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal hall frobenius.
+From mathcomp Require Import algC.
+From mathcomp Require Import mxrepresentation mxabelem classfun character.
+From mathcomp Require Import integral_char inertia vcharacter.
+From odd_order Require Import BGsection1 BGsection3 BGsection7 BGsection15.
+From odd_order Require Import BGsection16 PFsection1 PFsection2 PFsection3.
+From odd_order Require Import PFsection4 PFsection5 PFsection6 PFsection7.
+From odd_order Require Import PFsection8 PFsection9.
 
 (******************************************************************************)
 (* This file covers Peterfalvi, Section 10: Maximal subgroups of Types III,   *)
@@ -190,7 +185,7 @@ by have [[]] := compl_of_typeII maxS StypeP Stype2.
 Qed.
 Let w2_pr := FTtype345_core_prime.
 
-Definition FTtype345_TIirr_degree := truncC (mu2_ 0 #1 1%g).
+Definition FTtype345_TIirr_degree := Num.trunc (mu2_ 0 #1 1%g).
 Definition FTtype345_TIsign := delta_ #1.
 Local Notation d := FTtype345_TIirr_degree.
 Local Notation delta := FTtype345_TIsign.
@@ -202,7 +197,7 @@ Lemma FTtype345_constants :
   [/\ forall i j, j != 0 -> mu2_ i j 1%g = d%:R,
     forall j, j != 0 -> delta_ j = delta,
       (d > 1)%N
-    & n \in Cnat].
+    & n \in Num.nat].
 Proof.
 have nz_j1 : #1 != 0 :> Iirr W2 by rewrite Iirr1_neq0.
 have invj j: j != 0 -> mu2_ 0 j 1%g = d%:R /\ delta_ j = delta.
@@ -210,19 +205,19 @@ have invj j: j != 0 -> mu2_ 0 j 1%g = d%:R /\ delta_ j = delta.
   rewrite -(cforder_dprodr defW) -dprod_IirrEr in co_k_j1.
   have{co_k_j1} [[u Dj1u] _] := cycTIiso_aut_exists ctiWM co_k_j1.
   rewrite dprod_IirrEr -rmorphXn -Dj /= -!dprod_IirrEr -!/(w_ _ _) in Dj1u.
-  rewrite truncCK ?Cnat_irr1 //.
+  rewrite truncK ?Cnat_irr1 //.
   have: delta_ j *: mu2_ 0 j == cfAut u (delta_ #1 *: mu2_ 0 #1).
     by rewrite -!(cycTIiso_prTIirr pddM) -/ctiWM -Dj1u.
   rewrite raddfZsign /= -prTIirr_aut eq_scaled_irr signr_eq0 /= /mu2_.
-  by case/andP=> /eqP-> /eqP->; rewrite prTIirr_aut cfunE/= aut_Cnat ?Cnat_irr1.
+  by case/andP=> /eqP-> /eqP->; rewrite prTIirr_aut cfunE/= aut_natr ?Cnat_irr1.
 have d_gt1: (d > 1)%N.
-  rewrite ltn_neqAle andbC -eqC_nat -ltC_nat truncCK ?Cnat_irr1 //.
+  rewrite ltn_neqAle andbC -eqC_nat -ltC_nat truncK ?Cnat_irr1 //.
   rewrite irr1_gt0 /= eq_sym; apply: contraNneq nz_j1 => mu2_lin.
   have: mu2_ 0 #1 \is a linear_char by rewrite qualifE/= irr_char /= mu2_lin.
   by rewrite lin_irr_der1 => /(prTIirr0P ptiWM)[i /irr_inj/prTIirr_inj[_ ->]].
 split=> // [i j /invj[<- _] | _ /invj[//] | ]; first by rewrite prTIirr_1.
-have: (d%:R == delta %[mod w1])%C by rewrite truncCK ?Cnat_irr1 ?prTIirr1_mod.
-rewrite /eqCmod unfold_in -/n (negPf (neq0CG W1)) CnatEint => ->.
+have: (d%:R == delta %[mod w1])%C by rewrite truncK ?Cnat_irr1 ?prTIirr1_mod.
+rewrite /eqCmod unfold_in -/n (negPf (neq0CG W1)) natrEint => ->.
 rewrite divr_ge0 ?ler0n // [delta]signrE opprB addrA -natrD subr_ge0 ler1n.
 by rewrite -(subnKC d_gt1).
 Qed.
@@ -304,7 +299,7 @@ Local Notation alpha_on := supp_FTtype345_bridge.
 Lemma vchar_FTtype345_bridge i j : alpha_ i j \in 'Z[irr M].
 Proof.
 have [_ _ _ Nn] := FTtype345_constants.
-by rewrite !rpredB ?rpredZsign ?rpredZ_Cnat ?irr_vchar ?mem_zchar.
+by rewrite !rpredB ?rpredZsign ?rpredZ_nat ?irr_vchar ?mem_zchar.
 Qed.
 Local Notation Zalpha := vchar_FTtype345_bridge.
 Local Hint Resolve Zalpha : core.
@@ -322,7 +317,7 @@ Lemma norm_FTtype345_bridge i j :
 Proof.
 move=> nz_j; rewrite Dade_isometry ?alpha_on // cfnormBd ?cfnormZ; last first.
   by rewrite cfdotZr cfdotBl cfdotZl !o_mu2_zeta !(mulr0, subr0).
-have [_ _ _ /Cnat_ge0 n_ge0] := FTtype345_constants.
+have [_ _ _ /natr_ge0 n_ge0] := FTtype345_constants.
 rewrite ger0_norm // cfnormBd ?cfnorm_sign ?cfnorm_irr ?irrWnorm ?mulr1 //.
 by rewrite cfdotZr (cfdot_prTIirr pddM) (negPf nz_j) andbF ?mulr0.
 Qed.
@@ -347,7 +342,7 @@ have nX_2: '[X] = 2%:R.
   by rewrite addrC nY_n2.
 have Z_X: X \in 'Z[irr G].
   rewrite -[X](addrK Y) -Dalpha rpredB ?Zalpha_tau // defY big_map big_seq.
-  by apply: rpred_sum => psi S1psi; rewrite rpredZ_Cint // Ztau1 ?mem_zchar.
+  by apply: rpred_sum => psi S1psi; rewrite rpredZ_int // Ztau1 ?mem_zchar.
 apply: eq_signed_sub_cTIiso => // y Vy; rewrite -[X](addrK Y) -Dalpha -/delta.
 rewrite !cfunE !cycTIiso_restrict //; set rhs := delta * _.
 rewrite Dade_id ?defA0 //; last by rewrite setUC inE mem_class_support.
@@ -373,15 +368,15 @@ have [[_ _ _ Nn] [[Itau1 _] _]] := (FTtype345_constants, cohS1).
 set Y := - (n *: _); apply: canRL (addrK _) _; set X := _ + _.
 have Dalpha: (alpha_ i j)^\tau = X + Y by rewrite addrK.
 have nY_n2: '[Y] = n ^+ 2.
-  by rewrite cfnormN cfnormZ norm_Cnat // Itau1 ?mem_zchar // irrWnorm ?mulr1.
+  by rewrite cfnormN cfnormZ norm_natr // Itau1 ?mem_zchar // irrWnorm ?mulr1.
 pose S2 := zeta :: zeta^*%CF; pose S2tau1 := map tau1 S2.
-have S2_Y: Y \in 'Z[S2tau1] by rewrite rpredN rpredZ_Cnat ?mem_zchar ?mem_head.
+have S2_Y: Y \in 'Z[S2tau1] by rewrite rpredN rpredZ_nat ?mem_zchar ?mem_head.
 have sS21: {subset S2 <= calS1} by apply/allP; rewrite /= ccS1 ?S1zeta.
 have cohS2 : coherent_with S2 M^# tau tau1 := subset_coherent_with sS21 cohS1.
 have irrS2: {subset S2 <= irr M} by apply/allP; rewrite /= cfAut_irr irr_zeta.
 rewrite (FTtype345_bridge_coherence cohS2 Dalpha) //; last first.
   rewrite -[X]opprK cfdotNr opprD cfdotDr nY_n2 cfdotNl cfdotNr opprK cfdotZl.
-  by rewrite cfdotC alpha_zeta_n rmorphN conj_Cnat // mulrN addNr oppr0.
+  by rewrite cfdotC alpha_zeta_n rmorphN conj_natr // mulrN addNr oppr0.
 split=> [|_ /sS21/sS10//|]; last first.
   by apply/allP; rewrite /= !inE cfConjCK !eqxx orbT.
 by rewrite /= inE eq_sym; have [[_ /hasPn-> //]] := scohS0; apply: sS10.
@@ -420,8 +415,8 @@ have al_ij_zeta_s: '[al_ij^\tau, zeta^*^\tau1] = a.
   rewrite -!prTIirr_aut !cfdotBl !cfdotZl !o_mu2_zeta o_zeta_s !mulr0.
   by rewrite opprB !(subr0, rmorph0) add0r irrWnorm ?mulr1.
 have Zal_ij: al_ij^\tau \in 'Z[irr G] by apply: Zalpha_tau.
-have Za: a \in Cint.
-  by rewrite rpredD ?(Cint_Cnat Nn) ?Cint_cfdot_vchar ?Ztau1 ?(mem_zchar Szeta).
+have Za: a \in Num.int.
+  by rewrite rpredD ?(intr_nat Nn) ?Cint_cfdot_vchar ?Ztau1 ?(mem_zchar Szeta).
 have{al_ij_zeta_s} ub_da2: (d ^ 2)%:R * a ^+ 2 <= (2%:R + n ^+ 2) * w1%:R.
   have [k nz_k j'k]: exists2 k, k != 0 & k != j.
     have:= w2gt2; rewrite -nirrW2 (cardD1 0) (cardD1 j) !inE nz_j !ltnS lt0n.
@@ -438,10 +433,10 @@ have{al_ij_zeta_s} ub_da2: (d ^ 2)%:R * a ^+ 2 <= (2%:R + n ^+ 2) * w1%:R.
   have ZSmuk: mu_ k \in 'Z[calS] by rewrite mem_zchar ?calSmu.
   have <-: '[al_ij^\tau] * '[(mu_ k)^\tau1] = (2%:R + n ^+ 2) * w1%:R.
     by rewrite Itau1 // cfdot_prTIred eqxx mul1n norm_alpha.
-  by rewrite -Cint_normK ?cfCauchySchwarz // Cint_cfdot_vchar // Ztau1.
+  by rewrite -intr_normK ?cfCauchySchwarz // Cint_cfdot_vchar // Ztau1.
 suffices a0 : a = 0.
   by apply: (def_tau_alpha _ sSS0); rewrite // -sub0r -a0 addrK.
-apply: contraTeq (d_gt1) => /(sqr_Cint_ge1 Za) a2_ge1.
+apply: contraTeq (d_gt1) => /(sqr_intr_ge1 Za) a2_ge1.
 suffices: n == 0.
   rewrite mulf_eq0 invr_eq0 orbC -implyNb neq0CG /= subr_eq0 => /eqP Dd.
   by rewrite -ltC_nat -(normr_nat _ d) Dd normr_sign ltxx.
@@ -451,17 +446,17 @@ suffices: n ^+ 2 < n + 1.
   have: (2%N %| n * w1%:R)%C.
     rewrite divfK ?neq0CG // -signrN signrE addrA -(natrD _ d 1).
     by rewrite rpredB // dvdC_nat dvdn2 ?odd_double // oddD d_odd.
-  rewrite -(truncCK Nn) -mulrSr -natrM -natrX ltC_nat (dvdC_nat 2) pnatr_eq0.
-  rewrite dvdn2 oddM mFT_odd; case: (truncC n) => [|[|n1]] // _ /idPn[].
+  rewrite -(truncK Nn) -mulrSr -natrM -natrX ltC_nat (dvdC_nat 2) pnatr_eq0.
+  rewrite dvdn2 oddM mFT_odd; case: (Num.trunc n) => [|[|n1]] // _ /idPn[].
   by rewrite -leqNgt (ltn_exp2l 1).
 apply: lt_le_trans (_ : n * - delta + 1 <= _); last first.
   have ->: n + 1 = n * `|- delta| + 1 by rewrite normrN normr_sign mulr1.
-  rewrite lerD2r ler_wpM2l ?Cnat_ge0 ?real_ler_norm //.
+  rewrite lerD2r ler_wpM2l ?natr_ge0 ?real_ler_norm //.
   by rewrite rpredN ?rpred_sign.
 rewrite -(ltr_pM2r (ltC_nat 0 2)) mulrDl mul1r -[rhs in rhs + _]mulrA.
 apply: le_lt_trans (_ : n ^+ 2 * (w1%:R - 1) < _).
   rewrite -(subnKC w1gt2) -(@natrB _ _ 1) // ler_wpM2l ?leC_nat //.
-  by rewrite Cnat_ge0 ?rpredX.
+  by rewrite natr_ge0 ?rpredX.
 rewrite -(ltr_pM2l (gt0CG W1)) -/w1 2!mulrBr mulr1 mulrCA -exprMn.
 rewrite mulrDr ltrBlDl addrCA -mulrDr mulrCA mulrA -ltrBlDl.
 rewrite -mulrBr mulNr opprK divfK ?neq0CG // mulr_natr addrA subrK -subr_sqr.
@@ -528,7 +523,7 @@ have mu0_zeta_g: (mu_ 0 - zeta)^\tau g = 0.
   by rewrite -def_FTsignalizer0.
 have{mu0_zeta_g} zeta_g: zeta^\tau1 g = \sum_i eta_ i 0 g.
   by apply/esym/eqP; rewrite -subr_eq0 -{2}mu0_zeta_g tau1mu0 !cfunE sum_cfunE.
-have Zwg i: eta_ i 0 g \in Cint.
+have Zwg i: eta_ i 0 g \in Num.int.
   have Lchi: 'chi_i \is a linear_char by apply: irr_cyclic_lin.
   rewrite Cint_cycTIiso_coprime // dprod_IirrE irr0 cfDprod_cfun1r.
   rewrite (coprime_dvdr _ co_g_w1) // dvdn_cforder.
@@ -545,8 +540,8 @@ have odd_zeta_g: (zeta^\tau1 g == 1 %[mod 2])%C.
     rewrite ltn_neqAle val_eqE -irr_eq1 (eq_sym i) -(inj_eq irr_inj) andbA.
     by rewrite aut_IirrE odd_eq_conj_irr1 ?mFT_odd ?andbb.
   rewrite -{1}conjC_Iirr0 [w_ _ _]cycTIirr_aut -cfAut_cycTIiso.
-  by rewrite cfunE /= conj_Cint ?Zwg.
-rewrite norm_Cint_ge1 //; first by rewrite zeta_g rpred_sum.
+  by rewrite cfunE /= conj_intr ?Zwg.
+rewrite norm_intr_ge1 //; first by rewrite zeta_g rpred_sum.
 apply: contraTneq odd_zeta_g => ->.
 by rewrite eqCmod_sym /eqCmod subr0 /= (dvdC_nat 2 1).
 Qed.
@@ -622,7 +617,7 @@ have{nRT} uccT2: cfConjC_subset T2 calT.
 have scohT2 := subset_subcoherent scohT uccT2.
 have [tau2 cohT2]: coherent T2 S^# tauS.
   apply: (uniform_degree_coherence scohT2); rewrite /= !cfunE /= nu_r_1 eqxx.
-  by rewrite conj_Cnat ?Cnat_irr1 ?eqxx.
+  by rewrite conj_natr ?Cnat_irr1 ?eqxx.
 have [s nz_s] := has_nonprincipal_irr ntW2; have Smu_s := calSmu nz_s.
 pose alpha := mu_ s - d%:R *: zeta; pose beta := nu r - lambda.
 have Salpha: alpha \in 'Z[calS, M^#] by rewrite zcharD1_seqInd ?ZmuBzeta.
@@ -857,7 +852,7 @@ have NCpsiG: (cyclicTI_NC ctiWG psi^\tau < 2 * minn w1 w2)%N.
   rewrite -leC_nat -n2psiG n2psiGsum ler_wpDr ?cfnorm_ge0 // pair_bigA.
   rewrite (bigID z_a) big1 /= => [|ij /eqP->]; last by rewrite normCK mul0r.
   rewrite add0r -sumr_const ler_sum // => [[i j] nz_ij].
-  by rewrite expr_ge1 ?norm_Cint_ge1 // Da Cint_cfdot_vchar ?Zsigma ?irr_vchar.
+  by rewrite expr_ge1 ?norm_intr_ge1 // Da Cint_cfdot_vchar ?Zsigma ?irr_vchar.
 have nz_psiG00: '[psi^\tau, eta_ 0 0] != 0 by rewrite -Da a_00 oner_eq0.
 have [a_i|a_j] := small_cycTI_NC psiG_V0 NCpsiG nz_psiG00.
   have psiGi: psi^\tau = \sum_i eta_ i 0 + chi.
@@ -1026,7 +1021,7 @@ have{lt1d} [defS szS1 Dd Ddel Dn]:
     apply/idP/idP; apply: allP xi; last by rewrite all_cat !(introT allP _).
     by rewrite -(canLR negbK (has_predC _ _)) has_filter -/S3 S3nil.
   have: (w1 %| d%:R - delta)%C.
-    by rewrite unfold_in pnatr_eq0 eqn0Ngt w1_gt0 rpred_Cnat.
+    by rewrite unfold_in pnatr_eq0 eqn0Ngt w1_gt0 rpred_nat_num.
   rewrite /n Dd def_p_w1 /delta; case: (Idelta _) => [_|/idPn[] /=].
     by rewrite opprK -(natrD _ _ 1) subnK ?muln_gt0 // natrM mulfK ?neq0CG.
   rewrite mul2n -addnn -{1}(subnKC (ltnW w1gt2)) !addSn mulrSr addrK dvdC_nat.
@@ -1054,7 +1049,7 @@ have Dalpha i (al_ij := alpha_ i j) :
     by move=> S1lam; rewrite Dal_ij cfdotDl oXS1 // addr0 Da_.
   pose a := n + a_ (tau1 zeta); have [_ oS1S1] := orthonormalP o1S1.
   have Da_z: a_ (tau1 zeta) = - n + a by rewrite addKr.
-  have Za: a \in Cint.
+  have Za: a \in Num.int.
     rewrite rpredD ?Dn ?rpred_nat // Da_ // Cint_cfdot_vchar ?Zalpha_tau //=.
     by rewrite Ztau1 ?mem_zchar.
   have Da_z' lam: lam \in S1 -> lam != zeta -> a_ (tau1 lam) = a.
@@ -1073,12 +1068,12 @@ have Dalpha i (al_ij := alpha_ i j) :
     rewrite ler_wpDr ?cfnorm_ge0 // defY cfnorm_sum_orthonormal //.
     rewrite (big_rem (tau1 zeta)) ?map_f //= le_eqVlt; apply/predU1P; left.
     congr (_ + _).
-      by rewrite Da_z addrC Cint_normK 1?rpredD // rpredN Dn rpred_nat.
+      by rewrite Da_z addrC intr_normK 1?rpredD // rpredN Dn rpred_nat.
     rewrite (eq_big_seq (fun _ => a ^+ 2)) => [|tau1lam]; last first.
       rewrite rem_filter ?free_uniq ?orthonormal_free // filter_map.
       case/mapP=> lam; rewrite mem_filter /= andbC => /andP[S1lam].
       rewrite (inj_in_eq (Zisometry_inj Itau1)) ?mem_zchar // => zeta'lam ->.
-      by rewrite Da_z' // Cint_normK.
+      by rewrite Da_z' // intr_normK.
     rewrite big_tnth sumr_const card_ord size_rem ?map_f // size_map.
     by rewrite mulr_natl subn1.
   have{lb_n2alij} ub_a2: (size S1)%:R * a ^+ 2 <= 2%:R * a * n + 2%:R.
@@ -1087,18 +1082,18 @@ have Dalpha i (al_ij := alpha_ i j) :
     by rewrite -mulrA !mulr_natl; case: (S1) => // in S1zeta lb_n2alij *.
   have{ub_a2} ub_8a2: 8%:R * a ^+ 2 <= 4%:R * a + 2%:R.
     rewrite mulrAC Dn -natrM in ub_a2; apply: le_trans ub_a2.
-    rewrite -Cint_normK // ler_wpM2r ?exprn_ge0 ?normr_ge0 // leC_nat szS1.
+    rewrite -intr_normK // ler_wpM2r ?exprn_ge0 ?normr_ge0 // leC_nat szS1.
     rewrite (subn_sqr p 1) def_p_w1 subnK ?muln_gt0 // mulnA mulnK // mulnC.
     by rewrite -subnDA -(mulnBr 2%N _ 1%N) mulnA (@leq_pmul2l 4 2) ?ltn_subRL.
-  have Z_4a1: 4%:R * a - 1%:R \in Cint by rewrite rpredB ?rpredM ?rpred_nat.
+  have Z_4a1: 4%:R * a - 1%:R \in Num.int by rewrite rpredB ?rpredM ?rpred_nat.
   have{ub_8a2} ub_4a1: `|4%:R * a - 1| < 3%:R.
-    rewrite -ltr_sqr ?rpred_nat ?qualifE/= ?normr_ge0 // -natrX Cint_normK //.
+    rewrite -ltr_sqr ?rpred_nat ?qualifE/= ?normr_ge0 // -natrX intr_normK //.
     rewrite sqrrB1 exprMn -natrX -mulrnAl -mulrnA (natrD _ 8 1) ltrD2r.
     rewrite (natrM _ 2 4) (natrM _ 2 8) -!mulrA -mulrBr ltr_pM2l ?ltr0n //.
     by rewrite ltrBlDl (le_lt_trans ub_8a2) // ltrD2l ltr_nat.
   have{ub_4a1} a0: a = 0.
-    apply: contraTeq ub_4a1 => a_nz; have:= norm_Cint_ge1 Za a_nz.
-    rewrite real_ltr_norml ?real_ler_normr ?Creal_Cint //; apply: contraL.
+    apply: contraTeq ub_4a1 => a_nz; have:= norm_intr_ge1 Za a_nz.
+    rewrite real_ltr_norml ?real_ler_normr ?Rreal_int //; apply: contraL.
     case/andP; rewrite ltrBlDr -(natrD _ 3 1) gtr_pMr ?ltr0n //.
     rewrite ltrNl opprB -mulrN => /lt_le_trans/=/(_ _ (leC_nat 3 5)).
     by rewrite (natrD _ 1 4) ltrD2l gtr_pMr ?ltr0n //; do 2!move/lt_geF->.

--- a/theories/PFsection11.v
+++ b/theories/PFsection11.v
@@ -1,26 +1,21 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq path div choice fintype.
-From mathcomp
-Require Import tuple finfun bigop order prime ssralg poly finset center.
-From mathcomp
-Require Import fingroup morphism perm automorphism quotient action finalg zmodp.
-From mathcomp
-Require Import gfunctor gproduct cyclic commutator gseries nilpotent pgroup.
-From mathcomp
-Require Import sylow hall abelian maximal frobenius.
-From mathcomp
-Require Import matrix mxalgebra mxrepresentation mxabelem vector.
-From odd_order
-Require Import BGsection1 BGsection3 BGsection7 BGsection15 BGsection16.
-From mathcomp
-Require Import ssrnum ssrint algC classfun character inertia vcharacter.
-From odd_order
-Require Import PFsection1 PFsection2 PFsection3 PFsection4 PFsection5.
-From odd_order
-Require Import PFsection6 PFsection7 PFsection8 PFsection9 PFsection10.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div choice fintype tuple finfun bigop prime finset.
+From mathcomp Require Import order.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import ssralg finalg zmodp poly ssrnum ssrint archimedean.
+From mathcomp Require Import matrix mxalgebra vector.
+From mathcomp Require Import cyclic center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal hall frobenius.
+From mathcomp Require Import algC.
+From mathcomp Require Import mxrepresentation mxabelem classfun character.
+From mathcomp Require Import inertia vcharacter.
+From odd_order Require Import BGsection1 BGsection3 BGsection7 BGsection15.
+From odd_order Require Import BGsection16 PFsection1 PFsection2 PFsection3.
+From odd_order Require Import PFsection4 PFsection5 PFsection6 PFsection7.
+From odd_order Require Import PFsection8 PFsection9 PFsection10.
 
 (******************************************************************************)
 (* This file covers Peterfalvi, Section 11: Maximal subgroups of Types        *)
@@ -840,7 +835,7 @@ have tau_alpha i: tau (alpha_ i j) = eta_ i j - eta_ i 0 - n *: zeta1.
     by rewrite Dade_vchar // zchar_split vchar_FTtype345_bridge /=.
   have [Y S1_Y [X [Dphi oYX oXS1]]] := orthogonal_split (map tau1 S1) phi.
   (* This is the first part of 11.8.2 *)
-  have [a Za defY]: exists2 a, a \in Cint & Y = a *: sum_tau1 - n *: zeta1.
+  have [a Za defY]: exists2 a, a \in Num.int & Y = a *: sum_tau1 - n *: zeta1.
     have [a_ Da defY] := orthonormal_span (map_orthonormal Itau1 o1S1) S1_Y.
     have{} Da: {in S1, forall xi, a_ (tau1 xi) = '[phi, tau1 xi]}.
       by move=> xi Sxi; rewrite Da Dphi cfdotDl (orthoPl oXS1) ?map_f ?addr0.
@@ -872,7 +867,7 @@ have tau_alpha i: tau (alpha_ i j) = eta_ i j - eta_ i 0 - n *: zeta1.
     rewrite cfdotC Dphi cfdotDl (orthoPl oXS1) ?map_f // addr0.
     rewrite defY cfdotBl scaler_sumr cfproj_sum_orthonormal //.
     rewrite cfdotZl Itau1 ?mem_zchar ?n1S1 // mulr1 rmorphB opprD opprK.
-    by rewrite Dn rmorph_nat conj_Cint.
+    by rewrite Dn rmorph_nat conj_intr.
     have a_even: (2 %| a)%C. (* Third internal part of (11.8.5). *)
     have Zbeta: beta \in 'Z[irr G].
       rewrite -{1}(betaE i j) // rpredD ?rpredB ?Zphi ?cycTIiso_vchar //.
@@ -893,7 +888,7 @@ have tau_alpha i: tau (alpha_ i j) = eta_ i j - eta_ i 0 - n *: zeta1.
     rewrite defY cfnormD cfnormN !cfnormZ cfdotNr cfdotZr.
     rewrite cfnorm_map_orthonormal // -Dn Itau1 ?mem_zchar ?n1S1 // mulr1.
     rewrite scaler_sumr cfproj_sum_orthonormal // rmorphN addrAC.
-    rewrite Dn rmorphM/= !Cint_normK ?rpred_nat // !rmorph_nat conj_Cint // -Dn.
+    rewrite Dn rmorphM/= !intr_normK ?rpred_nat // !rmorph_nat conj_intr // -Dn.
     by rewrite -mulr2n mulrC mulrA -mulr_natr mulNr -mulrBr.
   have{a_even} Da: (a == 0) || (a == 2%:R). (* Second part of (11.8.2). *)
     suffices (b := a - 1): b ^+ 2 == 1.
@@ -904,10 +899,10 @@ have tau_alpha i: tau (alpha_ i j) = eta_ i j - eta_ i 0 - n *: zeta1.
       apply: le_trans; rewrite sqrrB1 -(mulr_natr a) -mulrBr mulrDr mulrA mulr1.
       rewrite lerD2r -(lerD2r (n ^+ 2 + '[X])) !addrA -nY -cfnormDd //.
       by rewrite -Dphi norm_FTtype345_bridge ?S1_1 // lerDl cfnorm_ge0.
-    have Zb: b \in Cint by rewrite rpredB ?rpred1 ?Za.
+    have Zb: b \in Num.int by rewrite rpredB ?rpred1 ?Za.
     have nz_b: b != 0 by rewrite subr_eq0 (memPn _ a a_even) ?(dvdC_nat 2 1).
-    rewrite eq_le sqr_Cint_ge1 {nz_b}//= andbT -Cint_normK // Dn -mulrnA.
-    have /CnatP[m ->] := Cnat_norm_Cint Zb; rewrite -natrX -natrM leC_nat.
+    rewrite eq_le sqr_intr_ge1 {nz_b}//= andbT -intr_normK // Dn -mulrnA.
+    have /natrP[m ->] := natr_norm_int Zb; rewrite -natrX -natrM leC_nat.
     by rewrite leq_pmul2l // lern1 -ltnS (ltn_sqr m 2) (leq_sqr m 1).
   have{nY Da} defX: X = eta_ i j - eta_ i 0. (* Last part of (11.8.2). *)
     have{nY Da} /eqP-nY: '[Y] == n ^+ 2.
@@ -915,7 +910,7 @@ have tau_alpha i: tau (alpha_ i j) = eta_ i j - eta_ i 0 - n *: zeta1.
     have coh_zeta_phi := FTtype345_bridge_coherence _ _ Szeta _ coh_tau1.
     have:= Dphi; rewrite addrC => /coh_zeta_phi->; rewrite ?S1_1 ?deltaZ //.
     rewrite defY scaler_sumr big_seq rpredB ?rpred_sum // => [xi Sxi|].
-      by rewrite rpredZ_Cint ?mem_zchar ?map_f.
+      by rewrite rpredZ_int ?mem_zchar ?map_f.
     by rewrite Dn rpredZnat ?mem_zchar ?map_f.
   have{col0_beta} a0: a = 0. (* This is the conclusion of (11.8.5). *)
     rewrite cfdot_suml big1 // in col0_beta => k _.
@@ -984,7 +979,7 @@ have: '[tau2 gamma, tau theta] != 0.
   rewrite (seqInd_ortho _ Txi) ?(memPn (sS1S2' _)) // !(mulr0, subr0) mulf_eq0.
   by rewrite char1_eq0 ?irrWchar // -cfnorm_eq0 irrWnorm ?oner_eq0 ?neq0CG.
 apply: contraNneq => o_muj_etaj; rewrite {}tau_theta !{gamma}raddfB subr_eq0 /=.
-have /CnatP[xi1 ->]: xi 1%g \in Cnat by rewrite Cnat_char1 ?irrWchar.
+have /natrP[xi1 ->]: xi 1%g \in Num.nat by rewrite Cnat_char1 ?irrWchar.
 rewrite mu_1 // cfdotZr !cfdotBl !raddfZnat !cfdotZl {}o_muj_etaj cfdot_sumr.
 have /orthogonalP oS2_S1: orthogonal (map tau2 S2) (map tau1 S1).
   exact: (coherent_ortho scohM) sS20 coh_tau2 sS10 coh_tau1 sS1S2'.
@@ -1031,14 +1026,14 @@ have bridgeS1: {in S1, forall zeta, eq_proj_eta (tau (bridge0 zeta)) eta0row}.
   have aut_phi nu: cfAut nu (tau phi) = tau phi + tau (zeta - cfAut nu zeta).
     rewrite -Dade_aut !rmorphB !raddfB /= !addrA subrK.
     by rewrite -prTIred_aut aut_Iirr0.
-  have Za i j: a_ i j \in Cint.
+  have Za i j: a_ i j \in Num.int.
     rewrite Da Cint_cfdot_vchar ?cycTIiso_vchar //.
     by rewrite Dade_vchar ?(zchar_onS sHU_A0).
   have [tau1 coh_tau1] := cohS1; have [_ Dtau1] := coh_tau1.
   have o_tau1_eta := coherent_ortho_cycTIiso MtypeP sS10 coh_tau1.
   have a_aut nu i j: a (cfAut nu (eta_ i j)) = a_ i j.
     symmetry; transitivity '[cfAut nu (tau phi), cfAut nu (eta_ i j)].
-      by rewrite cfdot_aut_vchar ?cycTIiso_vchar // -Da aut_Cint.
+      by rewrite cfdot_aut_vchar ?cycTIiso_vchar // -Da aut_intr.
     rewrite aut_phi cfAut_cycTIiso -cycTIirr_aut [a _]Da cfdotDl addrC.
     rewrite -Dtau1 ?zcharD1_seqInd ?seqInd_sub_aut_zchar // raddfB cfdotBl.
     by rewrite !o_tau1_eta ?cfAut_seqInd ?cfAut_irr // subr0 add0r.
@@ -1062,7 +1057,7 @@ have bridgeS1: {in S1, forall zeta, eq_proj_eta (tau (bridge0 zeta)) eta0row}.
   have normX: '[X] = 1 + q1 * a10 ^+ 2 + p1 * a01 ^+ 2 + p1 * q1 * a11 ^+ 2.
     transitivity (\sum_i \sum_j a_ i j ^+ 2).
       rewrite defX cfnorm_sum_orthonormal // sum_etaW.
-      by apply/eq_bigr=> i _; apply/eq_bigr=> j _; rewrite Cint_normK ?Za.
+      by apply/eq_bigr=> i _; apply/eq_bigr=> j _; rewrite intr_normK ?Za.
     rewrite -addrA addrACA (bigD1 0) //= (bigD1 0) //= a00_1 expr1n.
     rewrite -natrM !mulr_natl mulrnA -mulrnDl.
     rewrite -nirrW1 -nirrW2 -!(cardC1 0) -!sumr_const.
@@ -1075,11 +1070,11 @@ have bridgeS1: {in S1, forall zeta, eq_proj_eta (tau (bridge0 zeta)) eta0row}.
       rewrite Dade_isometry ?A0bridge0 // cfnormBd; last by rewrite omuS1.
       by rewrite cfnorm_prTIred cfdotS1 // eqxx addrC addKr.
     suffices: '[chi] != 0.
-      suffices /CnatP[nchi ->]: '[chi] \in Cnat by rewrite ler1n lt0n -eqC_nat.
+      suff/natrP[nchi ->]: '[chi] \in Num.nat by rewrite ler1n lt0n -eqC_nat.
       rewrite Cnat_cfnorm_vchar // -(canLR (addKr _) Dchi) defX addrC rpredB //.
          by rewrite Dade_vchar // (zchar_onS (FTsupp_sub0 M)) ?defA.
        rewrite big_map big_seq rpred_sum // => _ /(cycTIirrP defW)[i [j ->]].
-       by rewrite rpredZ_Cint ?Za ?cycTIiso_vchar.
+       by rewrite rpredZ_int ?Za ?cycTIiso_vchar.
     pose theta := zeta - zeta^*%CF.
     have Ztheta: theta \in 'Z[S1, HU^#] by apply: seqInd_sub_aut_zchar.
     have: '[tau phi, tau theta] != 0.
@@ -1092,14 +1087,14 @@ have bridgeS1: {in S1, forall zeta, eq_proj_eta (tau (bridge0 zeta)) eta0row}.
     rewrite cfdot_suml big_map big1_seq // => _ /(cycTIirrP defW)[i [j ->]].
     apply/eqP; rewrite cfdotC fmorph_eq0 cfdotZr raddfB cfdotBl.
     by rewrite !o_tau1_eta ?cfAut_seqInd ?cfAut_irr // subrr mulr0.
-  have a2_ge0 i j: 0 <= a_ i j ^+ 2 by rewrite -realEsqr Creal_Cint.
+  have a2_ge0 i j: 0 <= a_ i j ^+ 2 by rewrite -realEsqr Rreal_int.
   have a11_0: a11 = 0.
     have: ('[X] < (2 * q.-1)%:R).
       rewrite (le_lt_trans normX_le_q) // ltC_nat -subn1 mulnBr ltn_subRL.
       by rewrite !mul2n -!addnn ltn_add2r odd_prime_gt2 ?mFT_odd.
     apply: contraTeq => nz_a11; rewrite le_gtF // normX ler_wpDl //.
       by rewrite !mulr_natl ?addr_ge0 ?ler01 ?mulrn_wge0 ?a2_ge0.
-    rewrite -mulr_natl -natrM ?ler_pM ?natr_ge0 ?sqr_Cint_ge1 ?Za //.
+    rewrite -mulr_natl -natrM ?ler_pM ?natr_ge0 ?sqr_intr_ge1 ?Za //.
     by rewrite leC_nat leq_mul // -subn1 ltn_subRL odd_prime_gt2 ?mFT_odd.
   rewrite a11_0 expr0n /= mulr0 addr0 in normX.
   have a10_a01: a10 + a01 = 1.
@@ -1113,7 +1108,7 @@ have bridgeS1: {in S1, forall zeta, eq_proj_eta (tau (bridge0 zeta)) eta0row}.
       rewrite ltr_pwDr 1?mulr_gt0 ?ltr0n -?subn1 ?subn_gt0 ?prime_gt1 //.
         by rewrite lt_def sqrf_eq0 nz_a01 a2_ge0.
       rewrite -lerBlDl -(natrB _ (prime_gt0 pr_q)) subn1 -mulr_natl.
-      by rewrite ler_wpM2l ?ler0n // sqr_Cint_ge1 ?Za.
+      by rewrite ler_wpM2l ?ler0n // sqr_intr_ge1 ?Za.
     suffices <-: X = eta_col 0 by rewrite Dchi /eq_proj_eta addrC addKr.
     rewrite defX sum_etaW exchange_big (bigD1 0) //= addrC.
     rewrite big1 ?add0r => [|j nz_j]; first apply: eq_bigr => i _; last first.
@@ -1187,8 +1182,8 @@ have ua_1: (u %/ a)%:R * `|'[phi, tau2 lambda]| == 1.
   by rewrite big1 ?addr0 ?normr1 // => i k'i; rewrite proj_col_eta (negPf k'i).
 have Du: u = a.
   apply/eqP; rewrite -[a]mul1n eqn_mul ?(ltnW a_gt1) // -eqC_nat.
-  move: ua_1; rewrite Cnat_mul_eq1 ?rpred_nat //; first by case/andP.
-  rewrite Cnat_norm_Cint ?Cint_cfdot_vchar //; last by rewrite Ztau2 ?mem_zchar.
+  move: ua_1; rewrite natr_mul_eq1 ?rpred_nat //; first by case/andP.
+  rewrite natr_norm_int ?Cint_cfdot_vchar //; last by rewrite Ztau2 ?mem_zchar.
   rewrite Dade_vchar // zchar_split A0bridge0 //.
   by rewrite rpredB ?char_vchar ?prTIred_char ?irrWchar.
 have lequ: (q <= u)%N.

--- a/theories/PFsection12.v
+++ b/theories/PFsection12.v
@@ -1,34 +1,22 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq path div choice.
-From mathcomp
-Require Import fintype tuple finfun bigop order prime ssralg finset center.
-From mathcomp
-Require Import fingroup morphism perm automorphism quotient action finalg zmodp.
-From mathcomp
-Require Import gfunctor gproduct cyclic commutator gseries nilpotent pgroup.
-From mathcomp
-Require Import sylow hall abelian maximal frobenius.
-From mathcomp
-Require Import matrix mxalgebra mxpoly mxrepresentation mxabelem vector.
-From mathcomp
-Require Import falgebra fieldext finfield.
-From odd_order
-Require Import BGsection1 BGsection2 BGsection3 BGsection4 BGsection7.
-From odd_order
-Require Import BGsection14 BGsection15 BGsection16.
-From mathcomp
-Require Import ssrnum ssrint algC cyclotomic algnum.
-From mathcomp
-Require Import classfun character inertia vcharacter.
-From odd_order
-Require Import PFsection1 PFsection2 PFsection3 PFsection4 PFsection5.
-From odd_order
-Require Import PFsection6 PFsection7 PFsection8 PFsection9 PFsection10.
-From odd_order
-Require Import PFsection11.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div choice fintype tuple finfun bigop prime finset.
+From mathcomp Require Import order.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import ssralg finalg zmodp ssrnum ssrint archimedean.
+From mathcomp Require Import matrix mxalgebra mxpoly vector.
+From mathcomp Require Import cyclic center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal hall frobenius.
+From mathcomp Require Import falgebra fieldext algC cyclotomic algnum finfield.
+From mathcomp Require Import mxrepresentation mxabelem classfun character.
+From mathcomp Require Import inertia vcharacter.
+From odd_order Require Import BGsection1 BGsection2 BGsection3 BGsection4.
+From odd_order Require Import BGsection7 BGsection14 BGsection15 BGsection16.
+From odd_order Require Import PFsection1 PFsection2 PFsection3 PFsection4.
+From odd_order Require Import PFsection5 PFsection6 PFsection7 PFsection8.
+From odd_order Require Import PFsection9 PFsection10 PFsection11.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -307,7 +295,7 @@ have{t S_chi1t et} /eqP{2}->: '[a, psi2] == '[a^*%CF, psi2].
   rewrite (cfdot_complement (Dade_cfunS _ _)) ?(cfun_onS _ (Dade_cfunS _ _)) //.
   by rewrite FT_Dade_supportE FT_Dade1_supportE setTD -disjoints_subset.
 rewrite -2!raddfN opprB /= cfdot_conjCl -Dade_conjC rmorphB /= cfConjCK -/tau2.
-rewrite conj_Cint ?Cint_cfdot_vchar ?(Z_R1 a) // Dade_vchar //.
+rewrite conj_intr ?Cint_cfdot_vchar ?(Z_R1 a) // Dade_vchar //.
 rewrite (zchar_onS (FTsupp1_sub _)) // (zchar_sub_irr _ A1bchi2) //.
 exact: seqInd_vcharW.
 Qed.
@@ -1003,12 +991,12 @@ pose h := #|H|; have ub_a: a ^+ 2 * ((h%:R - 1) / e%:R) - 2%:R * a <= e%:R - 1.
     rewrite cfdotBl cfdotZl cfdot_suml (orthoPr o_tau1_Ga) ?map_f // subr0.
     rewrite big1_seq ?mulr0 // => xi Sxi; rewrite cfdotZl.
     by rewrite (orthoPr o_tau1_Ga) ?map_f ?mulr0.
-  rewrite cfnormB cfnormZ Cint_normK // cfdotZl cfproj_sum_orthonormal //.
+  rewrite cfnormB cfnormZ intr_normK // cfdotZl cfproj_sum_orthonormal //.
   rewrite cfnorm_sum_orthonormal // Itau1 ?mem_zchar // irrWnorm ?irrS // divr1.
-  rewrite chi1 divff ?neq0CG // mulr1 conj_Cint // addrAC mulr_natl.
+  rewrite chi1 divff ?neq0CG // mulr1 conj_intr // addrAC mulr_natl.
   rewrite !lerD2r !(mulr_suml, mulr_sumr) !big_seq ler_sum // => xi Sxi.
   rewrite irrWnorm ?irrS // !divr1 (mulrAC _^-1) -expr2 -!exprMn (mulrC _^-1).
-  by rewrite normf_div normr_nat norm_Cnat // (Cnat_seqInd1 Sxi).
+  by rewrite normf_div normr_nat norm_natr // (Cnat_seqInd1 Sxi).
 have [pr_p p_dv_M]: prime p /\ p %| #|M|.
   have: p \in \pi(M) by rewrite -p_rank_gt0 ltnW.
   by rewrite mem_primes => /and3P[].
@@ -1029,7 +1017,7 @@ have{ub_e} ub_a: p.-1.*2%:R * a ^+ 2 - 2%:R * a <= p.-1%:R / 2%:R :> algC.
   apply: le_trans (le_trans ub_a _); last first.
     rewrite -subn1 -subSS natrB ?ltnS ?prime_gt0 // mulrSr mulrBl.
     by rewrite divff ?pnatr_eq0 ?lerD2r.
-  rewrite lerD2r mulrC -Cint_normK // -!mulrA !ler_wpM2l ?normr_ge0 //.
+  rewrite lerD2r mulrC -intr_normK // -!mulrA !ler_wpM2l ?normr_ge0 //.
   rewrite ler_pdivlMr ?gt0CG // lerBrDr (le_trans _ lb_h) //.
   rewrite -muln2 natrM -mulrA -lerBrDr subr_sqr_1.
   rewrite -(natrB _ (prime_gt0 pr_p)) subn1 ler_wpM2l ?ler0n //.
@@ -1040,16 +1028,16 @@ have a0: a = 0.
   rewrite -ltrBrDr -mulrBr mulr_natl mulrA -expr2 -exprMn.
   apply: lt_le_trans (_ : 2%:R * ((a *+ 2) ^+ 2 - 1) <= _); last first.
     rewrite (mulr_natl a 2) ler_wpM2r // ?subr_ge0.
-      by rewrite sqr_Cint_ge1 ?rpredMn // mulrn_eq0.
+      by rewrite sqr_intr_ge1 ?rpredMn // mulrn_eq0.
     by rewrite leC_nat -subn1 ltn_subRL.
   rewrite -(@ltr_pM2l _ 2%:R) ?ltr0n // !mulrA -expr2 mulrBr -exprMn mulr1.
   rewrite -natrX 2!mulrnAr -[in rhs in _ < rhs]mulrnAl -mulrnA.
   rewrite ltrBrDl -ltrBrDr -(ltrD2r 1) -mulrSr -sqrrB1.
-  rewrite -Cint_normK ?rpredB ?rpredM ?rpred_nat ?rpred1 //.
+  rewrite -intr_normK ?rpredB ?rpredM ?rpred_nat ?rpred1 //.
   rewrite (lt_le_trans (y := (3 ^ 2)%:R)) ?ltC_nat // natrX.
   rewrite ler_sqr ?qualifE/= ?ler0n ?normr_ge0 //.
   rewrite (le_trans _ (lerB_dist _ _)) // normr1 normrM normr_nat.
-  by rewrite lerBrDl -mulrS mulr_natl ler_pMn2r ?norm_Cint_ge1.
+  by rewrite lerBrDl -mulrS mulr_natl ler_pMn2r ?norm_intr_ge1.
 pose chi0 := 'Ind[L, H] 1.
 have defS1: perm_eq (seqIndT H L) (chi0 :: calS).
   by rewrite [calS]seqIndC1_rem // perm_to_rem ?seqIndT_Ind1.
@@ -1068,7 +1056,7 @@ rewrite linearD linearZ /= cfdotDr cfdotZr psi_alpha_1 mulrN1 rmorphN opprK.
 rewrite -/tauL_H -Dtau1 ?zcharD1_seqInd ?(seqInd_sub_lin_vchar _ Schi) ?De //.
 have [_ ooS] := orthonormalP o1calS.
 rewrite raddfB cfdotBr Itau1 ?mem_zchar // ooS // mulrb ifN_eqC // add0r.
-rewrite -De raddfZ_Cnat ?(dvd_index_seqInd1 _ Sxi) // De cfdotZr.
+rewrite -De raddfZ_nat ?(dvd_index_seqInd1 _ Sxi) // De cfdotZr.
 by rewrite Itau1 ?mem_zchar ?ooS // eqxx mulr1 subrr !mul0r.
 Qed.
 
@@ -1077,7 +1065,7 @@ Let rhoM := invDade (FT_DadeF_hyp maxM).
 Let rhoM_psi :
   [/\ {in K^#, rhoM psi =1 psi},
       {in K :\: K' &, forall g1 g2, psi g1 = psi g2}
-    & {in K :\: K', forall g, psi g \in Cint}].
+    & {in K :\: K', forall g, psi g \in Num.int}].
 Proof.
 have pr_p: prime p.
   by have:= ltnW prankM; rewrite p_rank_gt0 mem_primes => /andP[].
@@ -1142,7 +1130,7 @@ have Dpsi_g: nK * '['Res[K] psi, 1] = nK' * '['Res[K'] psi, 1] + nKK' * psi g.
   exact: part2.
 have{} Zpsi: psi \in 'Z[irr G] by have [[_ ->//]] := cohS; apply: mem_zchar.
 have Qpsi1 R: '['Res[R] psi, 1] \in Crat.
-  by rewrite rpred_Cint ?Cint_cfdot_vchar ?rpred1 ?cfRes_vchar.
+  by rewrite rpred_int_num ?Cint_cfdot_vchar ?rpred1 ?cfRes_vchar.
 apply: Cint_rat_Aint (Aint_vchar g Zpsi).
 rewrite -[psi g](mulKf nzKK') -(canLR (addKr _) Dpsi_g) addrC mulrC.
 by rewrite rpred_div ?rpredB 1?rpredM ?rpred_nat ?Qpsi1.
@@ -1183,7 +1171,7 @@ have lb_psiM: '[rhoM psi] >= #|K :\: K'|%:R / #|M|%:R * e.-1%:R ^+ 2.
   rewrite -[e%:R]opprK (le_trans _ (lerB_dist _ _)) // normrN normrM.
   rewrite lerBrDl !normr_nat -natrD.
   apply: le_trans (_ : 1 * p%:R <= _); last first.
-    by rewrite ler_wpM2r ?ler0n ?norm_Cint_ge1.
+    by rewrite ler_wpM2r ?ler0n ?norm_intr_ge1.
   rewrite mul1r leC_nat -subn1 addnBA ?cardG_gt0 // leq_subLR addnn -ltnS.
   have [b e_dv_pb]: exists b : bool, e %| (b.*2 + p).-1.
     by have [_ /orP[]] := Ecyclic_le_p; [exists false | exists true].

--- a/theories/PFsection13.v
+++ b/theories/PFsection13.v
@@ -1,32 +1,22 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq path div choice fintype.
-From mathcomp
-Require Import tuple finfun bigop order prime binomial ssralg poly finset.
-From mathcomp
-Require Import fingroup morphism perm automorphism quotient action finalg zmodp.
-From mathcomp
-Require Import gfunctor gproduct center cyclic commutator gseries nilpotent.
-From mathcomp
-Require Import pgroup sylow hall abelian maximal frobenius.
-From mathcomp
-Require Import matrix mxalgebra mxrepresentation mxabelem vector.
-From odd_order
-Require Import BGsection1 BGsection3 BGsection7.
-From odd_order
-Require Import BGsection14 BGsection15 BGsection16.
-From mathcomp
-Require Import ssrnum rat algC cyclotomic algnum.
-From mathcomp
-Require Import classfun character integral_char inertia vcharacter.
-From odd_order
-Require Import PFsection1 PFsection2 PFsection3 PFsection4.
-From odd_order
-Require Import PFsection5 PFsection6 PFsection7 PFsection8 PFsection9.
-From odd_order
-Require Import PFsection10 PFsection11 PFsection12.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div choice fintype tuple finfun bigop prime finset.
+From mathcomp Require Import binomial order.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import ssralg finalg zmodp poly ssrnum archimedean rat.
+From mathcomp Require Import matrix mxalgebra vector.
+From mathcomp Require Import cyclic center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal hall frobenius.
+From mathcomp Require Import algC cyclotomic algnum.
+From mathcomp Require Import mxrepresentation mxabelem classfun character.
+From mathcomp Require Import integral_char inertia vcharacter.
+From odd_order Require Import BGsection1 BGsection3 BGsection7.
+From odd_order Require Import BGsection14 BGsection15 BGsection16.
+From odd_order Require Import PFsection1 PFsection2 PFsection3 PFsection4.
+From odd_order Require Import PFsection5 PFsection6 PFsection7 PFsection8.
+From odd_order Require Import PFsection9 PFsection10 PFsection11 PFsection12.
 
 (******************************************************************************)
 (* This file covers Peterfalvi, Section 13: The Subgroups S and T.            *)
@@ -417,7 +407,7 @@ have sHPU: H \subset PU by rewrite /= -(dprodWC defH) mulG_subG subIset ?sUPU.
 have [/eqfunP mu'zeta|] := boolP [forall j, '['Ind 'chi_t, chi_ j] == 0].
   right; rewrite Dzeta -(cfIndInd _ _ sHPU) ?gFsub //.
   rewrite ['Ind 'chi_t]cfun_sum_constt linear_sum /= rpred_sum // => s tPUs.
-  rewrite linearZ rpredZ_Cnat ?Cnat_cfdot_char ?cfInd_char ?irr_char //=.
+  rewrite linearZ rpredZ_nat ?Cnat_cfdot_char ?cfInd_char ?irr_char //=.
   have [[j Ds] | [irr_zeta _]] := prTIres_irr_cases ptiWS s.
     by case/eqP: tPUs; rewrite Ds mu'zeta.
   rewrite mem_zchar // mem_filter irr_zeta mem_seqInd ?gFnormal ?normal1 //=.
@@ -498,7 +488,7 @@ have Da_ zeta: zeta \in calH -> a_ zeta = '['Ind (zeta - zeta0), chi].
   move=> Tzeta; rewrite /a_ !calHuq // divff ?scale1r; last first.
     by rewrite pnatr_eq0 -lt0n muln_gt0 indexg_gt0 cardG_gt0.
   by rewrite [Dade _ _]DtauH ?H1dzeta.
-have Za_ zeta: zeta \in calH -> a_ zeta \in Cint.
+have Za_ zeta: zeta \in calH -> a_ zeta \in Num.int.
   move=> Hzeta; rewrite Da_ // Cint_cfdot_vchar ?cfInd_vchar //.
   by rewrite rpredB ?char_vchar ?(seqInd_char Hzeta) ?(seqInd_char Hzeta0).
 have{} Da_ zeta: zeta \in calS1 -> a_ zeta = '[tau1 zeta, chi].
@@ -512,7 +502,7 @@ have{} Dchi: {in H^#, forall x, chi x = a / '[zeta1] * zeta1 x + alpha x}.
   move=> x H1x; have [_ Hx] := setD1P H1x.
   transitivity (invDade ddH chi x).
     by rewrite cfunElock ddH_1 // big_set1 H1x mul1g cards1 invr1 mul1r.
-  rewrite cfResE ?gFsub ?Dchi // big_cons conj_Cint ?Za_ ?Da_ ?sS1H //= -/a.
+  rewrite cfResE ?gFsub ?Dchi // big_cons conj_intr ?Za_ ?Da_ ?sS1H //= -/a.
   congr (_ + _); rewrite big_cat /= sum_cfunE big1_seq ?add0r //= => [|zeta].
     by apply: eq_bigr => zeta; rewrite cfunE.
   rewrite ?(mem_rem_uniq, inE) ?rem_uniq ?filter_uniq ?seqInd_uniq //=.
@@ -528,11 +518,11 @@ have kerHalpha: {subset irr_constt alpha <= Iirr_ker H P}.
 have Zalpha: alpha \in 'Z[irr H].
   rewrite [alpha]rmorph_sum big_seq rpred_sum // => zeta; rewrite mem_filter /=.
   case/andP=> S1'zeta Tzeta; rewrite linearZ /= -scalerA.
-  rewrite rpredZ_Cint ?conj_Cint ?Za_ //; have [s _ ->] := seqIndP Tzeta.
+  rewrite rpredZ_int ?conj_intr ?Za_ //; have [s _ ->] := seqIndP Tzeta.
   rewrite cfResInd_sum_cfclass ?reindex_cfclass -?cfnorm_Ind_irr //=.
   rewrite scalerK ?cfnorm_eq0 ?cfInd_eq0 ?irr_neq0 ?irr_char ?gFsub //.
   by apply: rpred_sum => i _; apply: irr_vchar.
-have{Da_ Za_} Za: a \in Cint by rewrite -[a]Da_ ?Za_ ?sS1H.
+have{Da_ Za_} Za: a \in Num.int by rewrite -[a]Da_ ?Za_ ?sS1H.
 exists alpha => //; split=> //.
   set a1 := a / _ in Dchi; pose phi := a1 *: 'Res zeta1 + alpha.
   transitivity (#|H|%:R * '[phi] - `|phi 1%g| ^+ 2).
@@ -540,8 +530,8 @@ exists alpha => //; split=> //.
     rewrite (big_setD1 _ (group1 H)) addKr; apply: eq_bigr => x H1x.
     by have [_ Hx] := setD1P H1x; rewrite !cfunE cfResE // Dchi.
   have Qa1: a1 \in Creal.
-    apply: rpred_div; first by rewrite rpred_Cint.
-    by rewrite rpred_Cnat // Cnat_cfdot_char ?(seqInd_char S1zeta1).
+    apply: rpred_div; first by rewrite rpred_int_num.
+    by rewrite rpred_nat_num // Cnat_cfdot_char ?(seqInd_char S1zeta1).
   rewrite cfnormDd; last first.
     rewrite [alpha]cfun_sum_constt cfdotZl cfdot_sumr big1 ?mulr0 // => s.
     move/kerHalpha; rewrite inE cfdotZr mulrC cfdot_Res_l => kerPs.
@@ -550,11 +540,11 @@ exists alpha => //; split=> //.
     rewrite mulf_eq0 fmorph_eq0 => /norP[]; rewrite -!irr_consttE.
     by move=> /sub_cfker_constt_Ind_irr-> // /sub_cfker_constt_Ind_irr <-.
   rewrite cfnormZ 2!cfunE cfRes1 2?real_normK //; last first.
-    rewrite rpredD 1?rpredM // Creal_Cint ?Cint_vchar1 // ?char_vchar //.
+    rewrite rpredD 1?rpredM // Rreal_int ?Cint_vchar1 // ?char_vchar //.
     by rewrite (seqInd_char S1zeta1).
   rewrite mulrDr mulrCA sqrrD opprD addrACA; congr (_ + _); last first.
     rewrite (cfnormE (cfun_onG _)) mulVKf ?neq0CG //.
-    by rewrite (big_setD1 1%g) // Cint_normK ?Cint_vchar1 // addrC addKr.
+    by rewrite (big_setD1 1%g) // intr_normK ?Cint_vchar1 // addrC addKr.
   rewrite opprD addrA; congr (_ - _); last first.
     rewrite -[_ * a * _]mulrA -mulr_natl; congr (_ * _).
     by rewrite -[a1 * _]mulrA -(mulrA a); congr (_ * _); rewrite -mulrA mulrC.
@@ -565,7 +555,7 @@ exists alpha => //; split=> //.
   rewrite (cfnormE (cfun_onG _)) mulVKf ?neq0CG // mulrC.
   rewrite (cfnormE (seqInd_on nsHS S1zeta1)) mulVKf ?neq0CG //.
   by apply: eq_bigr => x Hx; rewrite cfResE.
-rewrite -subn1 natrB // -Cint_normK ?Cint_vchar1 // mulrBl mul1r lerBlDl.
+rewrite -subn1 natrB // -intr_normK ?Cint_vchar1 // mulrBl mul1r lerBlDl.
 apply: le_trans (_ : \sum_(x in H) `|alpha x| ^+ 2 <= _); last first.
   by rewrite (big_setD1 1%g).
 rewrite (big_setID P) /= (setIidPr sPH) ler_wpDr ?sumr_ge0 // => [x _|].
@@ -587,14 +577,15 @@ move=> cohS _ /zchar_expansion[|z Zz ->].
   by rewrite filter_uniq ?seqInd_uniq.
 rewrite raddf_sum cfdot_suml big1_seq //= => phi; rewrite mem_filter.
 case/andP=> irr_phi /(coherent_ortho_cycTIiso StypeP sSS0 cohS) o_phi_eta.
-by rewrite raddfZ_Cint {Zz}//= cfdotZl o_phi_eta ?mulr0.
+by rewrite raddfZ_int {Zz}//= cfdotZl o_phi_eta ?mulr0.
 Qed.
 
-Let P1_int2_lb b : b \in Cint -> 2%:R * u%:R * b <= #|P|.-1%:R * b ^+ 2.
+Let P1_int2_lb (b : algC) :
+  b \in Num.int -> 2%:R * u%:R * b <= #|P|.-1%:R * b ^+ 2.
 Proof.
 move=> Zb; rewrite -natrM; apply: le_trans (_ : (2 * u)%:R * b ^+ 2 <= _).
-  by rewrite ler_wpM2l ?ler0n ?Cint_ler_sqr.
-rewrite ler_wpM2r -?realEsqr ?Creal_Cint // leC_nat mulnC -leq_divRL //.
+  by rewrite ler_wpM2l ?ler0n ?intr_ler_sqr.
+rewrite ler_wpM2r -?realEsqr ?Rreal_int // leC_nat mulnC -leq_divRL //.
 have [_ [_ ->] /leq_trans-> //] := FTtypeP_facts.
 by rewrite leq_div2l // -subn1 ltn_subRL.
 Qed.
@@ -672,7 +663,7 @@ have{} Deta10: {in H^#, eta10 =1 alpha}.
 set a1_2 := alpha 1%g ^+ 2 in ub_alpha.
 have Dsum_alpha: \sum_(x in H^#) `|alpha x| ^+ 2 = #|H|%:R * '[alpha] - a1_2.
   rewrite (cfnormE (cfun_onG _)) mulVKf ?neq0CG // (big_setD1 _ (group1 H)) /=.
-  by rewrite addrC Cint_normK ?addKr ?Cint_vchar1.
+  by rewrite addrC intr_normK ?addKr ?Cint_vchar1.
 have [/mulG_sub[sPH _] [_ _ _ [_ _ sW2P _ _] _]] := (dprodW defH, StypeP).
 have nz_alpha: alpha != 0.
   have [[x W2x ntx] [y W1y nty]] := (trivgPn _ ntW2, trivgPn _ ntW1).
@@ -707,8 +698,8 @@ suffices{ub_alpha} lb_a1_2: a1_2 >= #|H^#|%:R.
     by rewrite -(subnKC Pgt2).
   have:= leq_trans (ltnW Pgt2) (subset_leq_card sPH).
   by rewrite [in X in X -> _](cardsD1 1%g) group1.
-have /CnatP[n Dn]: '[alpha] \in Cnat by rewrite Cnat_cfnorm_vchar.
-have /CnatP[m Dm]: a1_2 \in Cnat by rewrite Cnat_exp_even ?Cint_vchar1.
+have /natrP[n Dn]: '[alpha] \in Num.nat by rewrite Cnat_cfnorm_vchar.
+have /natrP[m Dm]: a1_2 \in Num.nat by rewrite natr_exp_even ?Cint_vchar1.
 rewrite Dm leC_nat leqNgt; apply: contra suma_lt_H => a1_2_lt_H.
 rewrite {1}Dsum_alpha Dn Dm -natrM lerBrDl (cardsD1 1%g H) group1 /=.
 case Dn1: n => [|[|n1]]; first by rewrite -cfnorm_eq0 Dn Dn1 eqxx in nz_alpha.
@@ -815,10 +806,10 @@ have eta11x: eta_ #1 #1 x = - (q%:R)^-1.
     by rewrite sum_eta1x_0 mulr0 add0r.
   rewrite cfunE signrMK mulr_natr -/q -nirrW1 -sumr_const sum_cfunE.
   by rewrite !(bigD1 0 isT) /= addrAC eta_i1 // (eq_bigr _ eta_i1).
-have: - eta_ #1 #1 x \in Cint.
+have: - eta_ #1 #1 x \in Num.int.
   rewrite rpredN Cint_rat_Aint ?Aint_vchar ?cycTIiso_vchar //.
   by rewrite eta11x rpredN rpredV rpred_nat.
-case/norm_Cint_ge1/implyP/idPn; rewrite eta11x opprK invr_eq0 neq0CG /=.
+case/norm_intr_ge1/implyP/idPn; rewrite eta11x opprK invr_eq0 neq0CG /=.
 by rewrite normfV normr_nat invf_ge1 ?gt0CG // lern1 -ltnNge ltnW.
 Qed.
 
@@ -1921,7 +1912,7 @@ have GammaReal: cfReal Gamma.
   rewrite rmorphB /= cfAutInd rmorph1 -prTIirr_aut aut_Iirr0 -/(beta_ _).
   by rewrite -Dtau ?A0beta ?defGamma ?aut_Iirr_eq0.
 split=> // X Y defXY oXY oYeta; pose a := '[Gamma, eta01].
-have Za: a \in Cint.
+have Za: a \in Num.int.
   rewrite Cint_cfdot_vchar 1?rpredD ?rpredB ?rpred1 ?cycTIiso_vchar //.
   by rewrite Dtau ?A0beta // !(cfInd_vchar, rpredB) ?rpred1 ?irr_vchar.
 have{} oYeta j: '[Y, eta_ 0 j] = 0.
@@ -1947,10 +1938,10 @@ rewrite cfnormDd; last first.
 rewrite cfnormDd; last first.
   rewrite cfdotZr !cfdotBl !cfdotZl Deta01s cfnorm_cycTIiso oXeta -Deta01s.
   rewrite !cfdot_conjCr o_eta1s1 conjC0 mulr0 ((_ =P Gamma) GammaReal) -/a.
-  by rewrite conj_Cint // mulr1 subr0 subrr mulr0.
+  by rewrite conj_intr // mulr1 subr0 subrr mulr0.
 rewrite -addrA ler_wpDl ?cfnorm_ge0 // !cfnormZ Deta01s !cfnorm_cycTIiso.
-rewrite !mulr1 !Cint_normK ?rpredB ?rpred1 // sqrrB1 !addrA -mulr2n.
-by rewrite -subr_ge0 addrK subr_ge0 ler_pMn2r ?Cint_ler_sqr.
+rewrite !mulr1 !intr_normK ?rpredB ?rpred1 // sqrrB1 !addrA -mulr2n.
+by rewrite -subr_ge0 addrK subr_ge0 ler_pMn2r ?intr_ler_sqr.
 Qed.
 
 (* The assumptions of Peterfalvi (13.19). *)
@@ -2105,10 +2096,10 @@ have Z_GaL: GammaL \in 'Z[irr G] by rewrite !rpredB ?rpred1.
 have{RealGammaL} Gamma_even: (2 %| '[GammaL, Gamma])%C.
   by rewrite cfdot_real_vchar_even ?mFT_odd // o_GaL_1 (dvdC_nat 2 0).
 set bSphi := '[tau betaS, tau1 phi]; set bLeta := '[tauL betaL, eta01].
-have [ZbSphi ZbLeta]: bSphi \in Cint /\ bLeta \in Cint.
+have [ZbSphi ZbLeta]: bSphi \in Num.int /\ bLeta \in Num.int.
   by rewrite !Cint_cfdot_vchar.
 have{Gamma_even} odd_bSphi_bLeta: (bSphi + bLeta == 1 %[mod 2])%C.
-  rewrite -(conj_Cint ZbSphi) -cfdotC /bLeta DbetaL cfdotDl cfdotBl.
+  rewrite -(conj_intr ZbSphi) -cfdotC /bLeta DbetaL cfdotDl cfdotBl.
   have: '[tauL betaL, tau betaS] == 0 by rewrite o_tauL_S ?Iirr1_neq0.
   have ->: tau betaS = 1 - eta01 + Gamma by rewrite addrCA !addrA !subrK.
   rewrite !['[tau1 _, _]]cfdotDr 2!cfdotDr !cfdotNr DbetaL.
@@ -2118,11 +2109,11 @@ have{Gamma_even} odd_bSphi_bLeta: (bSphi + bLeta == 1 %[mod 2])%C.
   rewrite cfdot_cycTIiso mulrb ifN_eqC ?Iirr1_neq0 // add0r.
   rewrite 2?(orthogonalP otau1eta _ _ (map_f _ _) (mem_eta _)) // oppr0 !add0r.
   by rewrite addr0 addrA addrC addr_eq0 !opprB addrA /eqCmod => /eqP <-.
-have abs_mod2 a: a \in Cint -> {b : bool | a == b%:R %[mod 2%N]}%C.
-  move=> Za; pose n := truncC `|a|; exists (odd n).
+have abs_mod2 a: a \in Num.int -> {b : bool | a == b%:R %[mod 2%N]}%C.
+  move=> Za; pose n := Num.trunc `|a|; exists (odd n).
   apply: eqCmod_trans (eqCmod_addl_mul _ (rpred_nat _ n./2) _).
-  rewrite addrC -natrM -natrD muln2 odd_double_half truncCK ?Cnat_norm_Cint //.
-  rewrite -{1}[a]mul1r -(canLR (signrMK _) (CintEsign Za)) eqCmodMr // signrE.
+  rewrite addrC -natrM -natrD muln2 odd_double_half truncK ?natr_norm_int //.
+  rewrite -{1}[a]mul1r -(canLR (signrMK _) (intrEsign Za)) eqCmodMr // signrE.
   by rewrite /eqCmod opprB addrC subrK dvdC_nat dvdn2 odd_double.
 have [[bL DbL] [bS DbS]] := (abs_mod2 _ ZbLeta, abs_mod2 _ ZbSphi).
 have{odd_bSphi_bLeta} xor_bS_bL: bS (+) bL.
@@ -2135,7 +2126,7 @@ have ?: (0 != 1 %[mod 2])%C by rewrite eqCmod_sym /eqCmod subr0 (dvdC_nat 2 1).
 case is_c1: bS; [left | right].
   rewrite is_c1 in DbS; split=> //.
   pose a_ (psi : 'CF(L)) := psi 1%g / e%:R.
-  have Na_ psi: psi \in calL -> a_ psi \in Cnat by apply: dvd_index_seqInd1.
+  have Na_ psi: psi \in calL -> a_ psi \in Num.nat by apply: dvd_index_seqInd1.
   have [X tau1X [D [dGa oXD oDtau1]]] := orthogonal_split (map tau1 calL) Gamma.
   have oo_L: orthonormal calL.
     by apply: sub_orthonormal (irr_orthonormal L); rewrite ?seqInd_uniq.
@@ -2148,8 +2139,8 @@ case is_c1: bS; [left | right].
     rewrite cfdotC cfdotDr cfdotBr -/betaS -/eta01.
     have ->: 1 = eta_ 0 0 by rewrite /w_ cycTIirr00 cycTIiso1.
     rewrite 2?(orthogonalP otau1eta _ _ (map_f _ _) (mem_eta _)) // subrK.
-    rewrite -cfdotC -(conj_Cnat (Na_ _ Lpsi)) -cfdotZr -cfdotBr.
-    rewrite -raddfZ_Cnat ?Na_ // -raddfB cfdotC.
+    rewrite -cfdotC -(conj_natr (Na_ _ Lpsi)) -cfdotZr -cfdotBr.
+    rewrite -raddfZ_nat ?Na_ // -raddfB cfdotC.
     rewrite Dtau1; last by rewrite zcharD1_seqInd ?seqInd_sub_lin_vchar.
     by rewrite o_tauL_S ?Iirr1_neq0 ?conjC0.
   have nz_bSphi: bSphi != 0 by apply: contraTneq DbS => ->.
@@ -2159,8 +2150,8 @@ case is_c1: bS; [left | right].
     - apply/orthoPl=> eta Weta; rewrite (span_orthogonal otau1eta) //.
       exact: memv_span.
     rewrite defX cfnormZ cfnorm_sum_orthonormal // mulr_sumr !big_seq.
-    apply: ler_sum => psi Lpsi; rewrite -{1}(norm_Cnat (Na_ _ _)) //.
-    by rewrite ler_peMl ?exprn_ge0 ?normr_ge0 // Cint_normK // sqr_Cint_ge1.
+    apply: ler_sum => psi Lpsi; rewrite -{1}(norm_natr (Na_ _ _)) //.
+    by rewrite ler_peMl ?exprn_ge0 ?normr_ge0 // intr_normK // sqr_intr_ge1.
   congr (_ <= _): ub_a; do 2!apply: (mulIf (neq0CiG L H)); rewrite -/e.
   rewrite divfK ?neq0CiG // -mulrA -expr2 mulr_suml.
   rewrite -subn1 natrB ?neq0CG // -indexg1 mulrC.
@@ -2190,8 +2181,8 @@ rewrite cfnormDd ?ler_wpDl ?cfnorm_ge0 //; last first.
   rewrite big_seq rpredD ?(rpredN, rpredZ, rpred_sum) ?memv_span ?map_f //.
   by move=> xi Lxi; rewrite rpredZ ?memv_span ?map_f.
 rewrite cfnormZ cfnorm_map_orthonormal // size_image cardC1 nirrW2.
-rewrite -(natrB _ (prime_gt0 pr_p)) Cint_normK // subn1.
-by rewrite ler_peMl ?ler0n ?sqr_Cint_ge1.
+rewrite -(natrB _ (prime_gt0 pr_p)) intr_normK // subn1.
+by rewrite ler_peMl ?ler0n ?sqr_intr_ge1.
 Qed.
 
 End Thirteen_17_to_19.

--- a/theories/PFsection14.v
+++ b/theories/PFsection14.v
@@ -1,32 +1,22 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq path div choice fintype.
-From mathcomp
-Require Import tuple finfun bigop order prime binomial ssralg poly finset.
-From mathcomp
-Require Import fingroup morphism perm automorphism quotient action finalg zmodp.
-From mathcomp
-Require Import gfunctor gproduct center cyclic commutator gseries nilpotent.
-From mathcomp
-Require Import pgroup sylow hall abelian maximal frobenius.
-From mathcomp
-Require Import matrix mxalgebra mxrepresentation mxabelem vector.
-From odd_order
-Require Import BGsection1 BGsection3 BGsection7.
-From odd_order
-Require Import BGsection14 BGsection15 BGsection16 BGappendixC.
-From mathcomp
-Require Import ssrnum rat algC cyclotomic algnum.
-From mathcomp
-Require Import classfun character integral_char inertia vcharacter.
-From odd_order
-Require Import PFsection1 PFsection2 PFsection3 PFsection4.
-From odd_order
-Require Import PFsection5 PFsection6 PFsection7 PFsection8 PFsection9.
-From odd_order
-Require Import PFsection10 PFsection11 PFsection12 PFsection13.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div choice fintype tuple finfun bigop prime finset.
+From mathcomp Require Import binomial order.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import ssralg finalg zmodp poly ssrnum archimedean rat.
+From mathcomp Require Import matrix mxalgebra vector.
+From mathcomp Require Import cyclic center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal hall frobenius.
+From mathcomp Require Import algC cyclotomic algnum.
+From mathcomp Require Import mxrepresentation mxabelem classfun character.
+From mathcomp Require Import integral_char inertia vcharacter.
+From odd_order Require Import BGsection1 BGsection3 BGsection7 BGsection14.
+From odd_order Require Import BGsection15 BGsection16 BGappendixC PFsection1.
+From odd_order Require Import PFsection2 PFsection3 PFsection4 PFsection5.
+From odd_order Require Import PFsection6 PFsection7 PFsection8 PFsection9.
+From odd_order Require Import PFsection10 PFsection11 PFsection12 PFsection13.
 
 (******************************************************************************)
 (* This file covers Peterfalvi, Section 14: Non_existence of G.               *)
@@ -234,12 +224,12 @@ have lb_b ij (b_ij := b (sigma 'chi_ij)):
     rewrite /a /w_ -Dij Dbeta defGa 2!cfdotDl.
     have ->: '[X, sigma 'chi_ij] = b_ij by rewrite /b_ij Db.
     by rewrite (orthoPl oYeta) ?(orthoPl oZeta) ?map_f ?mem_irr // !addr0.
-  have Zaij: a i j \in Cint by rewrite Cint_cfdot_vchar ?cycTIiso_vchar.
-  rewrite Cint_normK //; split.
-    rewrite sqr_Cint_ge1 //; apply: contraTneq (a_odd i j) => ->.
+  have Zaij: a i j \in Num.int by rewrite Cint_cfdot_vchar ?cycTIiso_vchar.
+  rewrite intr_normK //; split.
+    rewrite sqr_intr_ge1 //; apply: contraTneq (a_odd i j) => ->.
     by rewrite (eqCmod_nat 2 0 1).
   apply/eqP/exists_eqP=> [a2_1|[n ->]]; last by rewrite sqrr_sign.
-  rewrite (CintEsign Zaij) normC_def conj_Cint // -expr2 -a2_1 sqrtC1 mulr1.
+  rewrite (intrEsign Zaij) normC_def conj_intr // -expr2 -a2_1 sqrtC1 mulr1.
   by exists (a i j < 0).
 have ub_e: e%:R <= #|Iirr W|%:R ?= iff (e == p * q)%N :> algC.
   rewrite leif_nat_r card_Iirr_cyclic //; last by have [] := ctiWG.
@@ -350,19 +340,19 @@ have Lgt1: (1 < size calL)%N by apply: seqInd_nontrivial (mFT_odd _ ) _ Lphi.
 have [[_ _]] := Dade_Ind1_sub_lin cohL Lgt1 irr_phi Lphi phi1.
 rewrite -/tauL -/betaL -/calL => ZbetaL [Gamma [_ _ [b _ Dbeta]]]. 
 rewrite odd_Frobenius_index_ler ?mFT_odd // -/u => -[]// _ ub_Ga _ nz_a.
-have Za: a \in Cint by rewrite Cint_cfdot_vchar // ?Ztau1 ?mem_zchar.
+have Za: a \in Num.int by rewrite Cint_cfdot_vchar // ?Ztau1 ?mem_zchar.
 have [X M_X [Del [defGa oXD oDM]]] := orthogonal_split (map tau1M calM) Gamma.
 apply: le_trans ub_Ga; rewrite defGa cfnormDd // ler_wpDr ?cfnorm_ge0 //.
 suffices ->: '[X] = (a / v) ^+ 2 * (\sum_(xi <- calM) xi 1%g ^+ 2 / '[xi]).
   rewrite sum_seqIndC1_square // -(natrB _ (cardG_gt0 K)) subn1.
   rewrite exprMn !mulrA divfK ?neq0CiG // mulrAC -mulrA.
-  by rewrite ler_peMl ?sqr_Cint_ge1 // divr_ge0 ?ler0n.
+  by rewrite ler_peMl ?sqr_intr_ge1 // divr_ge0 ?ler0n.
 have [_ -> defX] := orthonormal_span o1M M_X.
 have Mgt1: (1 < size calM)%N by apply: seqInd_nontrivial (mFT_odd _ ) _ Mpsi.
 have [[oM1 _ _] _ _] := Dade_Ind1_sub_lin cohM Mgt1 irr_psi Mpsi psi1.
-rewrite exprMn -(Cint_normK Za) -[v]normr_nat -normfV -/v mulr_sumr.
+rewrite exprMn -(intr_normK Za) -[v]normr_nat -normfV -/v mulr_sumr.
 rewrite defX cfnorm_sum_orthonormal // big_map; apply: eq_big_seq => xi Mxi.
-have Zxi1 := Cint_seqInd1 Mxi; rewrite -(Cint_normK Zxi1) -(conj_Cint Zxi1).
+have Zxi1 := Cint_seqInd1 Mxi; rewrite -(intr_normK Zxi1) -(conj_intr Zxi1).
 rewrite irrWnorm ?irrM // divr1 -!exprMn -!normrM; congr (`|_| ^+ 2).
 rewrite -mulrA mulrC -mulrA; apply: canRL (mulKf (neq0CiG _ _)) _.
 rewrite -(canLR (addrK _) defGa) cfdotBl (orthoPl oDM) ?map_f // subr0.
@@ -371,7 +361,7 @@ rewrite (orthoPr oM1) ?map_f // (orthogonalP oML) ?map_f // subrr add0r.
 rewrite cfdotZr cfdot_sumr big1_seq ?mulr0 ?oppr0 => [|nu Mnu]; last first.
   by rewrite cfdotZr (orthogonalP oML) ?map_f ?mulr0.
 apply/eqP; rewrite conjC0 oppr0 add0r -subr_eq0 -conjC_nat -!cfdotZr.
-rewrite -raddfZnat -raddfZ_Cint // -cfdotBr -raddfB -/v -psi1.
+rewrite -raddfZnat -raddfZ_int // -cfdotBr -raddfB -/v -psi1.
 rewrite Dtau1 ?zcharD1_seqInd ?sub_seqInd_zchar //.
 rewrite (cfdotElr (Dade_cfunS _ _) (Dade_cfunS _ _)) setIC.
 by have:= TItauML; rewrite -setI_eq0 => /eqP->; rewrite big_set0 mulr0.
@@ -780,7 +770,7 @@ have nzT1_Ga zeta: zeta \in calT1 -> `|'[Gamma, tau1T zeta]| ^+ 2 >= 1.
   have Z_Ga: Gamma \in 'Z[irr G].
     rewrite rpredD ?cycTIiso_vchar // rpredB ?rpred1 ?Dade_vchar // zchar_split.
     by rewrite A0betaS ?Iirr1_neq0 // rpredB ?cfInd_vchar ?rpred1 ?irr_vchar.
-  move=> T1zeta; rewrite expr_ge1 ?normr_ge0 // norm_Cint_ge1 //.
+  move=> T1zeta; rewrite expr_ge1 ?normr_ge0 // norm_intr_ge1 //.
     by rewrite Cint_cfdot_vchar ?Ztau1T ?(mem_zchar T1zeta).
   suffices: ('[Gamma, tau1T zeta] == 1 %[mod 2])%C.
     by apply: contraTneq => ->; rewrite (eqCmod_nat 2 0 1).
@@ -955,12 +945,12 @@ have lbG0 g: g \in G0 -> 1 <= `|tau1M psi g| ^+ 2.
     rewrite -[\sum_i _](subrK chi) -DbetaM !cfunE betaMg0 add0r.
     case: Dchi => -> //; rewrite cfunE normrN.
     by rewrite -(cfConjC_Dade_coherent cohM) ?mFT_odd ?cfunE ?norm_conjC.
-  have{co_p_g} Zeta_g ij: sigma 'chi_ij g \in Cint.
+  have{co_p_g} Zeta_g ij: sigma 'chi_ij g \in Num.int.
     apply/Cint_cycTIiso_coprime/(coprime_dvdr (cforder_lin_char_dvdG _)).
       by apply: irr_cyclic_lin; have [] := ctiWG.
     rewrite -(dprod_card defW) coprimeMr.
     by apply/andP; split; [apply: co_p_g galT _ | apply: co_p_g galS _].
-  rewrite sum_cfunE norm_Cint_ge1 ?rpred_sum // => [ij _|].
+  rewrite sum_cfunE norm_intr_ge1 ?rpred_sum // => [ij _|].
     by rewrite cfunE rpredMsign.
   set a := \sum_i _; suffices: (a == 1 %[mod 2%N])%C.
     by apply: contraTneq=> ->; rewrite (eqCmod_nat 2 0 1).
@@ -981,7 +971,7 @@ have lbG0 g: g \in G0 -> 1 <= `|tau1M psi g| ^+ 2.
     by rewrite odd_eq_conj_irr1 ?mFT_odd // irr_eq1 nz_ij.
   rewrite -signr_odd -[odd _]negbK signrN !cfunE mulNr addrC.
   apply: eqCmod_trans (signCmod2 _ _) _.
-  by rewrite eqCmod_sym conjC_IirrE -cfAut_cycTIiso cfunE /= conj_Cint.
+  by rewrite eqCmod_sym conjC_IirrE -cfAut_cycTIiso cfunE /= conj_intr.
 have cardG_D1 R: #|R^#| = #|R|.-1 by rewrite [#|R|](cardsD1 1%g) group1.
 pose rho := invDade ddMK; pose nG : algC := #|G|%:R.
 pose sumG0 := \sum_(g in G0) `|tau1M psi g| ^+ 2.

--- a/theories/PFsection2.v
+++ b/theories/PFsection2.v
@@ -1,21 +1,16 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq path div choice.
-From mathcomp
-Require Import fintype tuple finfun bigop prime ssralg poly finset center.
-From mathcomp
-Require Import fingroup morphism perm automorphism quotient action zmodp.
-From mathcomp
-Require Import gfunctor gproduct cyclic pgroup frobenius ssrnum.
-From mathcomp
-Require Import matrix mxalgebra mxrepresentation vector algC classfun character.
-From mathcomp
-Require Import inertia vcharacter.
-From odd_order
-Require Import PFsection1.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div choice fintype tuple finfun bigop prime finset.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import ssralg zmodp poly ssrnum matrix mxalgebra vector.
+From mathcomp Require Import cyclic center gfunctor pgroup frobenius.
+From mathcomp Require Import algC.
+From mathcomp Require Import mxrepresentation classfun character inertia.
+From mathcomp Require Import vcharacter.
+From odd_order Require Import PFsection1.
 
 (******************************************************************************)
 (* This file covers Peterfalvi, Section 2: the Dade isometry                  *)

--- a/theories/PFsection3.v
+++ b/theories/PFsection3.v
@@ -1,22 +1,17 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq path div choice fintype.
-From mathcomp
-Require Import tuple finfun bigop order prime ssralg matrix poly finset.
-From mathcomp
-Require Import fingroup morphism perm automorphism quotient action finalg zmodp.
-From mathcomp
-Require Import gfunctor center gproduct cyclic pgroup abelian frobenius.
-From mathcomp
-Require Import mxalgebra mxrepresentation vector falgebra fieldext galois.
-From mathcomp
-Require Import ssrnum rat algC algnum classfun character.
-From mathcomp
-Require Import integral_char inertia vcharacter.
-From odd_order
-Require Import PFsection1 PFsection2.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div choice fintype tuple finfun bigop prime finset.
+From mathcomp Require Import order.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import ssralg zmodp finalg poly ssrnum archimedean rat.
+From mathcomp Require Import matrix mxalgebra vector.
+From mathcomp Require Import cyclic center gfunctor pgroup abelian frobenius.
+From mathcomp Require Import falgebra fieldext galois algC algnum.
+From mathcomp Require Import mxrepresentation classfun character integral_char.
+From mathcomp Require Import inertia vcharacter.
+From odd_order Require Import PFsection1 PFsection2.
 
 (******************************************************************************)
 (* This file covers Peterfalvi, Section 3: TI-Subsets with Cyclic Normalizers *)
@@ -510,7 +505,7 @@ rewrite defXY cfnormDd //; split; first by rewrite ler_wpDr ?cfnorm_ge0.
 have{ZmL} Zbeta: beta \in 'Z[irr G] by apply: ZmL.
 have Z_X: X \in 'Z[irr G].
   rewrite defX big_seq rpred_sum // => xi /sAm/ZmR Zxi.
-  by rewrite rpredZ_Cint ?Cint_cfdot_vchar.
+  by rewrite rpredZ_int ?Cint_cfdot_vchar.
 rewrite -ltrBlDl subrr cnorm_dconstt; last first.
   by rewrite -[Y](addKr X) -defXY addrC rpredB.
 have [-> | [dk Ydk] _ /eqP sz_kvs] := set_0Vmem (dirr_constt Y).
@@ -565,7 +560,7 @@ Proof.
 case: cl => ij kvs /satP thP th_cl /andP[cl'k ltkm].
 have [[_ ZmL _] [o1m ZmR]] := (LmodelP m, RmodelP m).
 have [m_ij Uij clP] := thP _ th_cl.
-have /CintP[v Dv]: '[m ij, m`_k] \in Cint.
+have /intrP[v Dv]: '[m ij, m`_k] \in Num.int.
   by rewrite Cint_cfdot_vchar ?ZmL ?ZmR ?mem_nth.
 have [/= th1 Dthx [th1_cl Dth1]] := ext_clP k v th_cl.
 suffices{Dthx} m_th1: sat m th1.
@@ -1401,7 +1396,7 @@ suffices /sigW[f /and3P[]]: exists f : {ffun _}, sigma_spec f.
   split=> [|_ /zchar_tuple_expansion[z Zz ->]].
     apply: isometry_in_zchar=> _ _ /irrP[k1 ->] /irrP[k2 ->] /=.
     by rewrite !lfunE dot_sigma ?map_f ?mem_irr // cfdot_irr (inj_eq inj_sigma).
-  rewrite linear_sum rpred_sum // => k _; rewrite linearZ rpredZ_Cint //=.
+  rewrite linear_sum rpred_sum // => k _; rewrite linearZ rpredZ_int //=.
   by rewrite -tnth_nth lfunE [sigma _]Dsigma ?mem_enum ?dchi_vchar.
 have [xi_ [xi00 Zxi Dxi o1xi]] := cyclicTIiso_basis_exists.
 pose f := [ffun k => dirr_dIirr (uncurry xi_) (inv_dprod_Iirr defW k)].
@@ -1595,7 +1590,7 @@ move=> Zphi ub_phi; apply: leq_trans (_ : #|dirr_constt phi| <= n)%N.
   elim/big_rec2: _ => [|/= i n1 phi1 _]; first by rewrite cycTI_NC_0.
   by apply: cycTI_NC_add; rewrite cycTI_NC_scale ?cycTI_NC_dchi.
 rewrite -leC_nat (le_trans _ ub_phi) ?cnorm_dconstt // -sumr_const.
-apply: ler_sum => i phi_i; rewrite sqr_Cint_ge1 ?Cint_Cnat ?Cnat_dirr //.
+apply: ler_sum => i phi_i; rewrite sqr_intr_ge1 ?intr_nat ?Cnat_dirr //.
 by rewrite gt_eqF -?dirr_consttE.
 Qed.
 
@@ -1704,7 +1699,7 @@ suffices /eqP eqIrho: Irho == Iphi by rewrite Drho eqIrho -Dphi signrZK.
 have psi_phi'_lt0 di: di \in Irho :\: Iphi -> '[psi, dchi di] < 0.
   case/setDP=> rho_di phi'di; rewrite cfdotBl subr_lt0.
   move: rho_di; rewrite dirr_consttE; apply: le_lt_trans.
-  rewrite real_leNgt -?dirr_consttE ?real0 ?Creal_Cint //.
+  rewrite real_leNgt -?dirr_consttE ?real0 ?Rreal_int //.
   by rewrite Cint_cfdot_vchar ?dchi_vchar.
 have NCpsi: (NC psi < 2 * minn w1 w2)%N.
   suffices NCpsi4: (NC psi <= 2 + 2)%N.
@@ -1816,7 +1811,7 @@ by rewrite [a]cforder_lin_char // dvdn_exponent.
 Qed.
 
 (* This is Peterfalvi (3.9)(c). *)
-Lemma Cint_cycTIiso_coprime x : coprime #[x] a -> sigma w x \in Cint.
+Lemma Cint_cycTIiso_coprime x : coprime #[x] a -> sigma w x \in Num.int.
 Proof.
 move=> co_x_a; apply: Cint_rat_Aint (Aint_vchar _ Zsigw).
 have [Qb galQb [QbC AutQbC [w_b genQb memQb]]] := group_num_field_exists <[x]>.

--- a/theories/PFsection4.v
+++ b/theories/PFsection4.v
@@ -1,20 +1,17 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq path div choice fintype.
-From mathcomp
-Require Import tuple finfun bigop order prime ssralg poly finset fingroup.
-From mathcomp
-Require Import morphism perm automorphism quotient action gfunctor gproduct.
-From mathcomp
-Require Import center commutator zmodp cyclic pgroup nilpotent hall frobenius.
-From mathcomp
-Require Import matrix mxalgebra mxrepresentation vector ssrnum algC classfun.
-From mathcomp
-Require Import character inertia vcharacter.
-From odd_order
-Require Import PFsection1 PFsection2 PFsection3.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div choice fintype tuple finfun bigop prime finset.
+From mathcomp Require Import order.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import ssralg zmodp poly ssrnum archimedean matrix.
+From mathcomp Require Import mxalgebra vector.
+From mathcomp Require Import cyclic center gfunctor commutator pgroup nilpotent.
+From mathcomp Require Import hall frobenius algC.
+From mathcomp Require Import mxrepresentation classfun character inertia.
+From mathcomp Require Import vcharacter.
+From odd_order Require Import PFsection1 PFsection2 PFsection3.
 
 (******************************************************************************)
 (* This file covers Peterfalvi, Section 4: The Dade isometry of a certain     *)
@@ -575,10 +572,10 @@ have lb_mu_1: w1%:R * 'chi_k 1%g <= mu_ j 1%g ?= iff (chi_j == 'chi_k).
   by apply: leif_eq; rewrite char1_ge0.
 pose psi := 'Ind 'chi_k - mu_ j; have Npsi: psi \is a character.
   apply/forallP=> l; rewrite coord_cfdot cfdotBl; set a := '['Ind _, _].
-  have Na: a \in Cnat by rewrite Cnat_cfdot_char_irr ?cfInd_char ?irr_char.
+  have Na: a \in Num.nat by rewrite Cnat_cfdot_char_irr ?cfInd_char ?irr_char.
   have [[i /eqP Dl] | ] := altP (@existsP _ (fun i => 'chi_l == mu2_ i j)).
-    have [n Da] := CnatP a Na; rewrite Da cfdotC Dl cfdot_prTIirr_red.
-    rewrite rmorph_nat -natrB ?Cnat_nat // eqxx lt0n -eqC_nat -Da.
+    have [n Da] := natrP Na; rewrite Da cfdotC Dl cfdot_prTIirr_red.
+    rewrite rmorph_nat -natrB ?natr_nat // eqxx lt0n -eqC_nat -Da.
     by rewrite -irr_consttE constt_Ind_Res Dl cfRes_prTIirr_eq0.
   rewrite negb_exists => /forallP muj'l.
   rewrite cfdot_suml big1 ?subr0 // => i _.
@@ -832,7 +829,7 @@ move=> eqjk; have{eqjk}: (delta_ j == delta_ k %[mod #|W1|])%C.
   apply: eqCmod_trans (prTIirr1_mod ptiWL i k).
   by rewrite eqCmod_sym -eqjk (prTIirr1_mod ptiWL).
 have /negP: ~~ (#|W1| %| 2) by rewrite gtnNdvd.
-rewrite /eqCmod -![delta_ _]intr_sign -rmorphB dvdC_int ?Cint_int //= intCK.
+rewrite /eqCmod -![delta_ _]intr_sign -rmorphB dvdC_int //= intrKfloor.
 by do 2!case: (primeTI_Isign _ _).
 Qed.
 
@@ -922,7 +919,7 @@ have real'T: ~~ has cfReal calT.
   by apply/hasPn=> _ /imageP[j /andP[nzj _] ->]; apply: prTIred_not_real.
 have ccT: cfConjC_closed calT.
   move=> _ /imageP[j Tj ->]; rewrite -prTIred_aut image_f // inE aut_Iirr_eq0.
-  by rewrite prTIred_aut cfunE/= conj_Cnat ?Cnat_char1 ?prTIred_char.
+  by rewrite prTIred_aut cfunE/= conj_natr ?Cnat_char1 ?prTIred_char.
 have TonA: 'Z[calT, L^#] =i 'Z[calT, A].
   have A'1: 1%g \notin A by apply: contra (subsetP sAA0 _) _; have [] := ddA0.
   move=> psi; rewrite zcharD1E -(setU1K A'1) zcharD1; congr (_ && _).

--- a/theories/PFsection5.v
+++ b/theories/PFsection5.v
@@ -1,20 +1,16 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq path div choice fintype.
-From mathcomp
-Require Import tuple finfun bigop order prime ssralg poly finset center.
-From mathcomp
-Require Import fingroup morphism perm automorphism quotient action zmodp.
-From mathcomp
-Require Import gfunctor gproduct cyclic pgroup frobenius.
-From mathcomp
-Require Import matrix mxalgebra mxrepresentation vector ssrint.
-From mathcomp
-Require Import ssrnum algC classfun character inertia vcharacter.
-From odd_order
-Require Import PFsection1 PFsection2 PFsection3 PFsection4.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div choice fintype tuple finfun bigop prime finset.
+From mathcomp Require Import order.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import ssralg zmodp poly ssrnum ssrint archimedean matrix.
+From mathcomp Require Import mxalgebra vector.
+From mathcomp Require Import cyclic center gfunctor pgroup frobenius algC.
+From mathcomp Require Import mxrepresentation classfun character inertia.
+From mathcomp Require Import vcharacter.
+From odd_order Require Import PFsection1 PFsection2 PFsection3 PFsection4.
 
 (******************************************************************************)
 (* This file covers Peterfalvi, Section 5: Coherence.                         *)
@@ -139,11 +135,11 @@ Proof. by move=> _ /seqIndP[i _ ->]; apply: cfInd_normal. Qed.
 Lemma seqInd_char : {subset S <= character}.
 Proof. by move=> _ /seqIndP[i _ ->]; rewrite cfInd_char ?irr_char. Qed.
 
-Lemma Cnat_seqInd1 phi : phi \in S -> phi 1%g \in Cnat.
+Lemma Cnat_seqInd1 phi : phi \in S -> phi 1%g \in Num.nat.
 Proof. by move/seqInd_char/Cnat_char1. Qed.
 
-Lemma Cint_seqInd1 phi : phi \in S -> phi 1%g \in Cint.
-Proof. by rewrite CintE; move/Cnat_seqInd1->. Qed.
+Lemma Cint_seqInd1 phi : phi \in S -> phi 1%g \in Num.int.
+Proof. by rewrite intrE; move/Cnat_seqInd1->. Qed.
 
 Lemma seqInd_neq0 psi : psi \in S -> psi != 0.
 Proof. by move=> /seqIndP[i _ ->]; apply: Ind_irr_neq0. Qed.
@@ -200,7 +196,7 @@ have{phi ZSphi} [c -> _] := free_span seqInd_free (zchar_span ZSphi).
 by rewrite big_seq memv_suml // => xi /A_S/memvZ.
 Qed.
 
-Lemma dvd_index_seqInd1 phi : phi \in S -> phi 1%g / e \in Cnat.
+Lemma dvd_index_seqInd1 phi : phi \in S -> phi 1%g / e \in Num.nat.
 Proof.
 by case/seqIndP=> i _ ->; rewrite cfInd1 // mulrC mulKf ?Cnat_irr1.
 Qed.
@@ -252,7 +248,7 @@ Lemma seqInd_sub_lin_vchar :
   {in S, forall phi : 'CF(L), phi - (phi 1%g / e) *: xi \in 'Z[S, K^#]}.
 Proof.
 move=> phi Sphi; rewrite /= zcharD1 !cfunE xi1 divfK // subrr eqxx.
-by rewrite rpredB ?scale_zchar ?seqInd_zchar // CintE dvd_index_seqInd1.
+by rewrite rpredB ?scale_zchar ?seqInd_zchar // intrE dvd_index_seqInd1.
 Qed.
 
 Lemma seqInd_sub_lin_on :
@@ -543,7 +539,7 @@ split=> [|{Inu Znu oSS} phi ZSphi].
   have{oSS} ccZS := cfAut_zchar ccS.
   have vcharS: {subset S <= 'Z[irr L]} by move=> phi /charS/char_vchar.
   split=> [phi1 phi2 Sphi1 Sphi2 | phi Sphi].
-    rewrite cfdotNl cfdotNr opprK Inu ?ccZS // cfdot_conjC aut_Cint //.
+    rewrite cfdotNl cfdotNr opprK Inu ?ccZS // cfdot_conjC aut_intr //.
     by rewrite Cint_cfdot_vchar ?(zchar_sub_irr vcharS).
   by rewrite rpredN Znu ?ccZS.
 rewrite -{}Dnu //; move: ZSphi; rewrite zcharD1E => /andP[].
@@ -553,8 +549,8 @@ case: S charS nrS ccS szS2 x Zx => [_ _ _ _ x _| eta S1].
 case/allP/andP=> Neta _ /norP[eta'c _] /allP/andP[S1_etac _].
 rewrite inE [_ == _](negPf eta'c) /= in S1_etac.
 case S1E: S1 S1_etac => [|u []] // /predU1P[] //= <- _ z Zz.
-rewrite big_ord_recl big_ord1 !raddfD/= !raddfZ_Cint //=.
-rewrite !cfunE/= (conj_Cnat (Cnat_char1 Neta)) -mulrDl mulf_eq0.
+rewrite big_ord_recl big_ord1 !raddfD !raddfZ_int //=.
+rewrite !cfunE/= (conj_natr (Cnat_char1 Neta)) -mulrDl mulf_eq0.
 rewrite addr_eq0 char1_eq0 // !scalerN /= cfConjCK addrC.
 by case/pred2P => ->; rewrite ?raddf0 //= !scaleNr opprK.
 Qed.
@@ -591,7 +587,7 @@ Qed.
 Lemma pivot_coherence S (tau : {additive 'CF(L) -> 'CF(G)}) R eta1 zeta1 :
     subcoherent S tau R -> eta1 \in S -> zeta1 \in 'Z[irr G] ->
     {in [predD1 S & eta1], forall eta : 'CF(L),
-      exists2 a, a \in Cnat /\ eta 1%g = a * eta1 1%g
+      exists2 a, a \in Num.nat /\ eta 1%g = a * eta1 1%g
               & '[tau (eta - a *: eta1), zeta1] = - a * '[eta1]} ->
    '[zeta1] = '[eta1] ->
   coherent S L^# tau.
@@ -599,7 +595,7 @@ Proof.
 case=> -[N_S _ _] [Itau Ztau] oSS _ _ Seta1 Zzeta1 isoS Izeta1.
 have freeS := orthogonal_free oSS; have uniqS := free_uniq freeS.
 have{oSS} [/andP[S'0 _] oSS] := pairwise_orthogonalP oSS.
-pose d := eta1 1%g; pose a (eta : 'CF(L)) := truncC (eta 1%g / d).
+pose d := eta1 1%g; pose a (eta : 'CF(L)) := Num.trunc (eta 1%g / d).
 have{S'0} nzd: d != 0 by rewrite char1_eq0 ?N_S ?(memPn S'0).
 pose S1 := eta1 :: [seq eta - eta1 *+ a eta | eta <- rem eta1 S].
 have sS_ZS1: {subset S <= 'Z[S1]}; last apply: (subgen_coherent sS_ZS1).
@@ -616,7 +612,7 @@ have{} isoS: {in behead S1, forall zeta, iso_eta1 zeta}.
   rewrite /iso_eta1 => _ /mapP[eta Seta ->]; rewrite mem_rem_uniq // in Seta.
   have{Seta} [/isoS[q [Nq Dq] Itau_eta1] [eta1'eta Seta]] := (Seta, andP Seta).
   rewrite zcharD1E rpredB ?rpredMn ?mem_zchar //= -scaler_nat /a Dq mulfK //.
-  by rewrite truncCK // !cfunE Dq subrr cfdotBl cfdotZl -mulNr oSS ?add0r.
+  by rewrite truncK // !cfunE Dq subrr cfdotBl cfdotZl -mulNr oSS ?add0r.
 have isoS1: {in S1, isometry [eta tau with eta1 |-> zeta1], to 'Z[irr G]}.
   split=> [xi eta | eta]; rewrite !in_cons /=; last first.
     by case: eqP => [-> | _  /isoS[/Ztau/zcharW]].
@@ -629,7 +625,7 @@ have{phi1_0} b_eta1_0: b eta1 = 0.
   have:= phi1_0; rewrite sum_cfunE big_cons big_seq big1 ?addr0 => [|zeta].
     by rewrite !cfunE (mulIr_eq0 _ (mulIf nzd)) => /eqP.
   by case/isoS; rewrite cfunE zcharD1E => /andP[_ /eqP->] _; rewrite mulr0.
-rewrite !raddf_sum; apply/eq_big_seq=> xi S1xi/=; rewrite !raddfZ_Cint //=.
+rewrite !raddf_sum; apply/eq_big_seq=> xi S1xi/=; rewrite !raddfZ_int //=.
 by rewrite Dnu //=; case: eqP => // ->; rewrite b_eta1_0 !scale0r.
 Qed.
 
@@ -649,7 +645,7 @@ have [[_ dotSS] oS] := (orthonormalP o1S, orthonormal_orthogonal o1S).
 pose beta chi := tau (chi - chi^*%CF); pose eqBP := _ =P beta _.
 have Zbeta: {in S, forall chi, chi - (chi^*)%CF \in 'Z[S, L^#]}.
   move=> chi Schi; rewrite /= zcharD1E rpredB ?mem_zchar ?ccS //= !cfunE.
-  by rewrite subr_eq0/= conj_Cnat // Cnat_char1 ?N_S.
+  by rewrite subr_eq0/= conj_natr // Cnat_char1 ?N_S.
 pose sum_beta chi R := \sum_(alpha <- R) alpha == beta chi.
 pose Zortho R := all (mem 'Z[irr G]) R && orthonormal R.
 have R chi: {R : 2.-tuple 'CF(G) | (chi \in S) ==> sum_beta chi R && Zortho R}.
@@ -809,7 +805,7 @@ split=> // [|phi Sphi|phi xi Sphi Sxi].
     by rewrite -(cycTIiso_eqE ddA) (inj_eq (can_inj (signrZK _))).
   have [Tstruct [tau1 Dtau1 [_ Dtau]]] := uniform_prTIred_coherent ddA nz_j.
   have{Tstruct} [/orthogonal_free freeT _ ccT _ _] := Tstruct.
-  have phi1c: (phi 1%g)^* = phi 1%g := conj_Cnat (Cnat_seqInd1 (sSS0 _ Sphi)).
+  have phi1c: (phi 1%g)^* = phi 1%g := conj_natr (Cnat_seqInd1 (sSS0 _ Sphi)).
   rewrite -[tau _]Dtau; last first.
     rewrite zcharD1E !cfunE/= phi1c subrr Dphi eqxx andbT.
     by rewrite rpredB ?mem_zchar ?ccT ?image_f ?inE // nz_j eqxx.
@@ -873,7 +869,7 @@ have [X RX [Y [defXY oXY oYR]]] := orthogonal_split (R chi) beta.
 exists X; last first.
   by exists (- Y); rewrite opprK (orthogonal_oppl Y) cfdotNr oXY oppr0.
 have [_ -> ->] := orthonormal_span oRR RX; rewrite big_seq rpred_sum // => a Ra.
-rewrite rpredZ_Cint ?mem_zchar // -(addrK Y X) -defXY.
+rewrite rpredZ_int ?mem_zchar // -(addrK Y X) -defXY.
 by rewrite cfdotBl (orthoPl oYR) // subr0 Cint_cfdot_vchar // ZR.
 Qed.
 
@@ -916,7 +912,7 @@ have normX: '[X1] <= '[X] ?= iff (X == X1).
   by rewrite cfdotBl (orthoPl oYR) // subr0 subrr mulr0.
 pose is01a xi := a xi == (a xi != 0)%:R.
 have leXa xi: a xi <= `|a xi| ^+ 2 ?= iff is01a xi.
-  rewrite Cint_normK //; split; first by rewrite Cint_ler_sqr.
+  rewrite intr_normK //; split; first by rewrite intr_ler_sqr.
   rewrite eq_sym -subr_eq0 -[lhs in _ - lhs]mulr1 -mulrBr mulf_eq0 subr_eq0.
   by rewrite /is01a; case a_xi_0: (a xi == 0).
 have{nchi normX} part_a: '[chi] <= '[X] ?= iff all is01a (R chi) && (X == X1).
@@ -1038,19 +1034,19 @@ exists tau3; split=> {ZItau3}// eta; rewrite zcharD1E.
 case/andP=> /(zchar_expansion (free_uniq (orthogonal_free oS3)))[b Zb {eta}->].
 pose bS Si := \sum_(xi <- Si) b xi *: xi.
 have ZbS Si: bS Si \in 'Z[Si].
-  by rewrite /bS big_seq rpred_sum // => eta /mem_zchar/rpredZ_Cint->.
+  by rewrite /bS big_seq rpred_sum // => eta /mem_zchar/rpredZ_int->.
 rewrite big_cat /= -!/(bS _) cfunE addrC addr_eq0 linearD => /eqP-bS2_1.
 transitivity (tau1 (bS S1) + tau2 (bS S2)).
   by rewrite !raddf_sum; congr (_ + _); apply/eq_big_seq=> xi Si_xi /=;
-     rewrite !raddfZ_Cint // -(defY1, defY2).
-have Z_S1_1 psi: psi \in 'Z[S1] -> psi 1%g \in Cint.
+     rewrite !raddfZ_int // -(defY1, defY2).
+have Z_S1_1 psi: psi \in 'Z[S1] -> psi 1%g \in Num.int.
   by move/zchar_sub_irr=> Zpsi; apply/Cint_vchar1/Zpsi => ? /N_S1/char_vchar.
 apply/(scalerI nz_chi1)/(addIr (- bS S1 1%g *: tau (chi - phi))).
-rewrite [in LHS]tau_chi_phi !scalerDr -!raddfZ_Cint ?rpredN ?Z_S1_1 //=.
+rewrite [in LHS]tau_chi_phi !scalerDr -!raddfZ_int ?rpredN ?Z_S1_1 //=.
 rewrite addrACA -!raddfD -raddfB !scalerDr !scaleNr scalerN !opprK.
 rewrite Dtau2/= ?Dtau1 ?zcharD1E ?cfunE; first by rewrite -raddfD addrACA.
-  by rewrite mulrC subrr rpredB ?rpredZ_Cint ?Z_S1_1 /=.
-by rewrite mulrC bS2_1 -chi1_phi mulNr addNr rpredD ?rpredZ_Cint ?Z_S1_1 /=.
+  by rewrite mulrC subrr rpredB ?rpredZ_int ?Z_S1_1 /=.
+by rewrite mulrC bS2_1 -chi1_phi mulNr addNr rpredD ?rpredZ_int ?Z_S1_1 /=.
 Qed.
 
 (* This is essentially Peterfalvi (5.6.3), which gets reused in (9.11.8).     *)
@@ -1061,7 +1057,7 @@ Qed.
 Lemma extend_coherent_with S1 (tau1 : {additive 'CF(L) -> 'CF(G)}) chi phi a X :
     cfConjC_subset S1 S -> coherent_with S1 L^# tau tau1 ->
     [/\ phi \in S1, chi \in S & chi \notin S1] ->
-    [/\ a \in Cint, chi 1%g = a * phi 1%g & '[X, a *: tau1 phi] = 0] ->
+    [/\ a \in Num.int, chi 1%g = a * phi 1%g & '[X, a *: tau1 phi] = 0] ->
     tau (chi - a *: phi) = X - a *: tau1 phi ->
   coherent (chi :: chi^*%CF :: S1) L^# tau.
 Proof.
@@ -1079,7 +1075,7 @@ have /orthoPl o_chi_S1: orthogonal chi S1.
 have Zdchi: chi - chi^*%CF \in 'Z[S, L^#].
   by rewrite sub_aut_zchar ?zchar_onG ?mem_zchar ?ccS // => xi /N_S/char_vchar.
 have [||_] := subcoherent_norm _ _ (erefl _) (And3 tau_beta oXaphi o_aphi_R).
-- rewrite Schi rpredZ_Cint ?char_vchar ?N_S /orthogonal //= !cfdotZr.
+- rewrite Schi rpredZ_int ?char_vchar ?N_S /orthogonal //= !cfdotZr.
   by rewrite cfdot_conjCl !o_chi_S1 ?ccS1 // conjC0 !mulr0 !eqxx.
 - apply: sub_iso_to ZItau; [apply: zchar_trans_on; apply/allP | exact: zcharW].
   by rewrite /= Zbeta Zdchi.
@@ -1112,13 +1108,13 @@ have [|tau2 [tau2X tau2Xc] Itau2] := Zisometry_of_cfnorm oS2 oX2 nX2.
   by rewrite !rpred_sum // => xi; rewrite mem_filter => /andP[_ /ZR].
 have{Itau2} cohS2: coherent_with S2 L^# tau tau2.
   split=> // psi; rewrite zcharD1E => /andP[/zchar_expansion[//|z Zz ->]].
-  rewrite big_cons big_seq1 !cfunE/= conj_Cnat ?Cnat_char1 ?N_S // addrC addr_eq0.
+  rewrite big_cons big_seq1 !cfunE/= conj_natr ?Cnat_char1 ?N_S // addrC addr_eq0.
   rewrite -mulNr (inj_eq (mulIf _)) ?char1_eq0 ?N_S // => /eqP->.
-  by rewrite scaleNr -scalerBr !raddfZ_Cint // raddfB /= tau2X tau2Xc -def_XXc.
-have: tau beta = tau2 chi - tau1 (a *: phi) by rewrite tau2X raddfZ_Cint.
+  by rewrite scaleNr -scalerBr !raddfZ_int // raddfB /= tau2X tau2Xc -def_XXc.
+have: tau beta = tau2 chi - tau1 (a *: phi) by rewrite tau2X raddfZ_int.
 apply: (bridge_coherent sS20 cohS2 sS10 cohS1) => //.
   by apply/hasPn; rewrite has_sym !negb_or S1'chi (contra (ccS1 _)) ?cfConjCK.
-by rewrite mem_head (zchar_on Zbeta) rpredZ_Cint ?mem_zchar.
+by rewrite mem_head (zchar_on Zbeta) rpredZ_int ?mem_zchar.
 Qed.
 
 (* This is Peterfalvi (5.6): Feit's result that a coherent set can always be  *)
@@ -1157,16 +1153,16 @@ have [eqXY oXY oYRchi] := defXY; pose X1 := map tau1 (in_tuple S1).
 suffices defY: Y = a *: tau1 xi1.
   by move: eqXY; rewrite defY; apply: extend_coherent_with; rewrite -?defY.
 have oX1: pairwise_orthogonal X1 by apply: map_pairwise_orthogonal.
-have N_S1_1 xi: xi \in S1 -> xi 1%g \in Cnat by move/sS1S/N_S/Cnat_char1.
+have N_S1_1 xi: xi \in S1 -> xi 1%g \in Num.nat by move/sS1S/N_S/Cnat_char1.
 have oRchiX1 psi: psi \in 'Z[R chi] -> orthogonal psi X1.
   move/zchar_span=> Rpsi; apply/orthoPl=> chi2 /memv_span.
   by apply: span_orthogonal Rpsi; rewrite orthogonal_sym coherent_ortho_supp.
 have [lam Zlam [Z oZS1 defY]]:
-  exists2 lam, lam \in Cint & exists2 Z : 'CF(G), orthogonal Z (map tau1 S1) &
-    Y = a *: tau1 xi1 - lam *: (\sum_(xi <- X1) a_ xi *: xi) + Z.
+  exists2 lam, lam \in Num.int & exists2 Z : 'CF(G), orthogonal Z (map tau1 S1)
+    & Y = a *: tau1 xi1 - lam *: (\sum_(xi <- X1) a_ xi *: xi) + Z.
 - pose lam := a * '[xi1] - '[Y, tau1 xi1]; exists lam.
     rewrite rpredD ?mulr_natl ?rpredN //.
-      by rewrite rpredM // CintE Cnat_cfdot_char ?N_S.
+      by rewrite rpredM // intrE Cnat_cfdot_char ?N_S.
     rewrite Cint_cfdot_vchar ?Ztau1 ?Z_S1 // -(subrK X Y) -opprB -eqXY addrC.
     by rewrite rpredB // (zchar_trans ZRchi).
   set Z' := _ - _; exists (Y - Z'); last by rewrite addrC subrK.
@@ -1180,12 +1176,12 @@ have [lam Zlam [Z oZS1 defY]]:
   rewrite [in lam * _]mulrA divfK // mul0r mulrBl opprB.
   rewrite -addrA [_ * xi1 _ + _]addrCA [a * _ * _ + _]addrC.
   rewrite !addrA !oXtau1 // !mulNr.
-  rewrite -(conj_Cnat (N_S1_1 _ S1xi)) -(conj_Cnat (N_S1_1 _ S1xi1)).
+  rewrite -(conj_natr (N_S1_1 _ S1xi)) -(conj_natr (N_S1_1 _ S1xi1)).
   rewrite opprK [- _ + _]addrC -!(mulrC _^*) -!cfdotZr -cfdotBr.
-  rewrite -!raddfZ_Cnat ?N_S1_1 // -raddfB; set beta : 'CF(L) := _ - _.
+  rewrite -!raddfZ_nat ?N_S1_1 // -raddfB; set beta : 'CF(L) := _ - _.
   have Zbeta: beta \in 'Z[S1, L^#].
     rewrite zcharD1E !cfunE mulrC subrr eqxx.
-    by rewrite rpredB ?rpredZ_Cint ?Z_S1 // CintE N_S1_1.
+    by rewrite rpredB ?rpredZ_int ?Z_S1 // intrE N_S1_1.
   rewrite -eqXY Dtau1 // Itau // ?(zchar_subset sS1S) //.
   rewrite cfdotBl !cfdotBr !cfdotZr !ocS1 // !mulr0 subrr add0r !cfdotZl.
   by rewrite opprB addrAC subrK subrr.
@@ -1198,15 +1194,15 @@ have [||leXchi _] := subcoherent_norm _ _ (erefl _) defXY.
 have normXY: '[X] + '[Y] = '[chi] + '[a *: xi1].
   by rewrite -!cfnormBd // ?cfdotZr ?ocS1 ?mulr0 // -eqXY Itau.
 have{leXchi normXY}: '[Y] <= a ^+ 2 * '[xi1].
-  by rewrite -(lerD2l '[X]) normXY cfnormZ Cint_normK // lerD2r.
+  by rewrite -(lerD2l '[X]) normXY cfnormZ intr_normK // lerD2r.
 rewrite {}defY cfnormDd; last first.
   rewrite cfdotC (span_orthogonal oZS1) ?rmorph0 ?memv_span1 //.
   rewrite big_seq memvB ?memvZ ?memv_suml ?memv_span ?map_f //.
   by move=> theta S1theta; rewrite memvZ ?memv_span.
-rewrite -cfnormN opprB cfnormB !cfnormZ !Cint_normK // addrAC lerBlDl.
+rewrite -cfnormN opprB cfnormB !cfnormZ !intr_normK // addrAC lerBlDl.
 rewrite cfdotZl cfdotZr cfnorm_sum_orthogonal ?cfproj_sum_orthogonal ?map_f //.
 rewrite a_xi1 Itau1 ?Z_S1 // addrAC lerD2r !(divfK, mulrA) ?nz_nS1 //.
-rewrite !conj_Cint ?rpredM // => /le_gtF-lb_2_lam_a.
+rewrite !conj_intr ?rpredM // => /le_gtF-lb_2_lam_a.
 suffices lam0: lam = 0; last apply: contraFeq lb_2_lam_a => nz_lam.
   suffices ->: Z = 0 by rewrite lam0 scale0r subrK.
   by apply: contraFeq lb_2_lam_a; rewrite -cfnorm_gt0 lam0 expr0n !mul0r !add0r.
@@ -1214,8 +1210,8 @@ rewrite ltr_wpDr ?cfnorm_ge0 // -mulr2n -mulr_natl mulrCA.
 have xi11_gt0: xi1 1%g > 0 by rewrite char1_gt0 ?N_S ?sS1S -?cfnorm_eq0 ?nz_nS1.
 have a_gt0: a > 0 by rewrite -(ltr_pM2r xi11_gt0) mul0r -chi1 char1_gt0.
 apply: le_lt_trans (_ : lam ^+ 2 * (2%:R * a) < _).
-  by rewrite ler_pM2r ?mulr_gt0 ?ltr0n ?Cint_ler_sqr.
-rewrite ltr_pM2l ?(lt_le_trans ltr01) ?sqr_Cint_ge1 {lam Zlam nz_lam}//.
+  by rewrite ler_pM2r ?mulr_gt0 ?ltr0n ?intr_ler_sqr.
+rewrite ltr_pM2l ?(lt_le_trans ltr01) ?sqr_intr_ge1 {lam Zlam nz_lam}//.
 rewrite -(ltr_pM2r xi11_gt0) -mulrA -chi1 -(ltr_pM2r xi11_gt0).
 congr (_ < _): ub_chi1; rewrite -mulrA -expr2 mulr_suml big_map.
 apply/eq_big_seq=> xi S1xi; rewrite a_E // Itau1 ?mem_zchar //.
@@ -1255,14 +1251,14 @@ have oSc xi: xi \in S -> '[xi, xi^*] = 0.
   by move=> Sxi; rewrite oSS ?ccS // eq_sym (hasPn nrS).
 pose D xi := tau (chi1 - xi).
 have Z_D xi: xi \in S -> D xi \in 'Z[irr G] by move/(Zd _ _ Schi1)/Ztau/zcharW.
-have /CnatP[N defN]: '[chi1] \in Cnat by rewrite Cnat_cfdot_char ?N_S.
+have /natrP[N defN]: '[chi1] \in Num.nat by rewrite Cnat_cfdot_char ?N_S.
 have dotD: {in S1 chi1 &, forall xi1 xi2, '[D xi1, D xi2] = N%:R + '[xi1, xi2]}.
   move=> xi1 xi2 /andP[ch1'xi1 Sxi1] /andP[chi1'xi2 Sxi2].
   rewrite Itau ?Zd // cfdotBl !cfdotBr defN.
   by rewrite 2?oSS // 1?eq_sym // opprB !subr0.
 have /R_P[ZRchi oRchi defRchi] := Schi1.
 have szRchi: size (R chi1) = (N + N)%N.
-  apply: (can_inj natCK); rewrite -cfnorm_orthonormal // -defRchi.
+  apply: (can_inj (@natrK algC)); rewrite -cfnorm_orthonormal // -defRchi.
   by rewrite dotD ?inE ?ccS ?(hasPn nrS) // cfnorm_conjC defN -natrD.
 pose subRchi1 X := exists2 E, subseq E (R chi1) & X = \sum_(a <- E) a.
 pose Xspec X := [/\ X \in 'Z[R chi1], '[X] = N%:R & subRchi1 X].
@@ -1322,8 +1318,8 @@ have [X [RchiX nX defX] XD_N]: exists2 X, Xspec X & XDspec X.
   have /haveX[X' [RchiX' nX' _] [Rxi3X' X'D_N]] := S2xi.
   have [sRchiX' sRxi1X'] := (zchar_span RchiX', zchar_span Rxi3X').
   suffices: '[X - X'] == 0 by rewrite cfnorm_eq0 subr_eq0 => /eqP->.
-  have ZXX': '[X, X'] \in Cint by rewrite Cint_cfdot_vchar ?(zchar_trans ZRchi).
-  rewrite cfnormB subr_eq0 nX nX' aut_Cint {ZXX'}//; apply/eqP/esym.
+  have ZXX': '[X, X'] \in Num.int by rewrite Cint_cfdot_vchar ?(zchar_trans ZRchi).
+  rewrite cfnormB subr_eq0 nX nX' aut_intr {ZXX'}//; apply/eqP/esym.
   congr (_ *+ 2); rewrite -(addNKr (X - D xi1) X) cfdotDl cfdotC.
   rewrite (span_orthogonal (oR chi1 xi1 _ _)) // conjC0.
   rewrite -(subrK (D xi) X') cfdotDr cfdotDl cfdotNl opprB subrK.
@@ -1389,7 +1385,7 @@ pose sum_eta a ell := \sum_i a i ell *: eta_ i ell.
 have [R [subcohS oS1sig defR]] := prDade_subcoherent ddA uccS nrS.
 have [[charS _ ccS] _ /orthogonal_free freeS Rok _] := subcohS.
 have [[Itau1 _] Dtau1] := cohS.
-have natS1 xi: xi \in S -> xi 1%g \in Cnat by move/charS/Cnat_char1.
+have natS1 xi: xi \in S -> xi 1%g \in Num.nat by move/charS/Cnat_char1.
 have k'j: j != k by rewrite -(inj_eq (prTIred_inj ddA)) prTIred_aut (hasPn nrS).
 have nzSmu l (Sl : mu l \in S): l != 0.
   apply: contraNneq (hasPn nrS _ Sl) => ->.
@@ -1435,7 +1431,7 @@ pose V := cyclicTIset defW; have zetaV0: {in V, tau1 zeta =1 \0}.
 pose zeta1 := zeta 1%g *: mu k - mu k 1%g *: zeta.
 have Zzeta1: zeta1 \in 'Z[S, L^#].
   rewrite zcharD1E !cfunE mulrC subrr eqxx andbT.
-  by rewrite rpredB ?scale_zchar ?mem_zchar // CintE ?natS1.
+  by rewrite rpredB ?scale_zchar ?mem_zchar // intrE ?natS1.
 have /cfun_onP A1zeta1: zeta1 \in 'CF(L, 1%g |: A).
   rewrite memvB ?memvZ ?prDade_TIred_on //; have [_ sSS0 _] := uccS.
   have /seqIndP[kz /setIdP[kerH'kz _] Dzeta] := sSS0 _ Szeta.
@@ -1451,7 +1447,7 @@ have{o_phi_0 zeta1V0} proj_phi0 i ell: '[phi, eta_ i ell] = '[phi, eta_ 0 ell].
   have: tau zeta1 x == 0.
     have [_ _ defA0] := prDade_def ddA; rewrite Dade_id ?zeta1V0 //.
     by rewrite defA0 inE orbC mem_class_support.
-  rewrite -Dtau1 // raddfB !raddfZ_Cnat ?natS1 // !cfunE zetaV0 //.
+  rewrite -Dtau1 // raddfB !raddfZ_nat ?natS1 // !cfunE zetaV0 //.
   rewrite oppr0 mulr0 addr0 mulf_eq0 => /orP[/idPn[] | /eqP->//].
   by have /irrP[iz ->] := irr_zeta; apply: irr1_neq0.
 have Dphi_j i: '[phi, eta_ i j] = a i j.
@@ -1530,7 +1526,7 @@ have sSZS: {subset calS <= 'Z[calS]} by move=> phi Sphi; apply: mem_zchar.
 pose mu j := 'chi_j 1%g *: 'chi_i - 'chi_i 1%g *: 'chi_j.
 have ZAmu j: 'chi_j \in calS -> mu j \in 'Z[calS, L^#].
   move=> Sxj; rewrite zcharD1E !cfunE mulrC subrr.
-  by rewrite rpredB //= scale_zchar ?sSZS // ?Cint_Cnat ?Cnat_irr1.
+  by rewrite rpredB //= scale_zchar ?sSZS // ?intr_nat ?Cnat_irr1.
 have Npsi j: 'chi_j \in calS -> '[tau1 'chi_j] = 1%:R.
   by move=> Sxj; rewrite Itau1 ?sSZS ?cfnorm_irr.
 have{Npsi} Dtau1 Sxj := vchar_norm1P (Ztau1 _ (sSZS _ Sxj)) (Npsi _ Sxj).
@@ -1543,8 +1539,8 @@ have{} Dtau1 j: 'chi_j \in calS -> exists t, tau1 'chi_j = eps *: 'chi_t.
     by rewrite cfunE oppr_ge0 lt_geF ?irr1_gt0.
   rewrite -(pmulr_rge0 _ (irr1_gt0 i)) cfunE mulrCA.
   have: tau1 (mu j) 1%g == 0 by rewrite tau1_tau ?ZAmu ?Dade1.
-  rewrite raddfB 2?raddfZ_Cnat ?Cnat_irr1 // !cfunE subr_eq0 => /eqP <-.
-  by rewrite tau1_chi cfunE mulrCA signrMK mulr_ge0 ?Cnat_ge0 ?Cnat_irr1.
+  rewrite raddfB 2?raddfZ_nat ?Cnat_irr1 // !cfunE subr_eq0 => /eqP <-.
+  by rewrite tau1_chi cfunE mulrCA signrMK mulr_ge0 ?natr_ge0 ?Cnat_irr1.
 have SuSirr j: 'chi_j \in calS -> 'chi_(aut_Iirr u j) \in calS.
   by rewrite aut_IirrE => /sSuS.
 have [j Sxj neq_ij]: exists2 j, 'chi_j \in calS & 'chi_i != 'chi_j.
@@ -1552,7 +1548,7 @@ have [j Sxj neq_ij]: exists2 j, 'chi_j \in calS & 'chi_i != 'chi_j.
   by rewrite !inE -(inj_eq irr_inj) eq_sym => /andP[]; exists j.
 have: (tau1 (mu j))^u == tau1 (mu j)^u.
   by rewrite !tau1_tau ?cfAut_zchar ?ZAmu ?Dade_aut.
-rewrite !raddfB [-%R]lock !raddfZ_Cnat ?Cnat_irr1 //= -lock -!aut_IirrE.
+rewrite !raddfB [-%R]lock !raddfZ_nat ?Cnat_irr1 //= -lock -!aut_IirrE.
 have [/Dtau1[ru ->] /Dtau1[tu ->]] := (SuSirr i Schi, SuSirr j Sxj).
 have: (tau1 'chi_i)^u != (tau1 'chi_j)^u.
   apply: contraNneq neq_ij => /cfAut_inj/(isometry_raddf_inj Itau1)/eqP.
@@ -1560,7 +1556,7 @@ have: (tau1 'chi_i)^u != (tau1 'chi_j)^u.
 have /Dtau1[t ->] := Sxj; rewrite tau1_chi !cfAutZ_Cint ?rpred_sign //.
 rewrite !scalerA -!(mulrC eps) -!scalerA -!scalerBr -!aut_IirrE.
 rewrite !(inj_eq (scalerI _)) ?signr_eq0 // (inj_eq irr_inj) => /negPf neq_urt.
-have [/CnatP[a ->] /CnatP[b xj1]] := (Cnat_irr1 i, Cnat_irr1 j).
+have [/natrP[a ->] /natrP[b xj1]] := (Cnat_irr1 i, Cnat_irr1 j).
 rewrite xj1 eq_subZnat_irr neq_urt orbF andbC => /andP[_].
 by rewrite eqn0Ngt -ltC_nat -xj1 irr1_gt0 /= => /eqP->.
 Qed.

--- a/theories/PFsection6.v
+++ b/theories/PFsection6.v
@@ -1,22 +1,19 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq path div choice fintype.
-From mathcomp
-Require Import tuple finfun bigop order prime ssralg poly finset center.
-From mathcomp
-Require Import fingroup morphism perm automorphism quotient action zmodp.
-From mathcomp
-Require Import gfunctor gproduct cyclic pgroup commutator gseries nilpotent.
-From mathcomp
-Require Import sylow abelian maximal hall frobenius.
-From mathcomp
-Require Import matrix mxalgebra mxrepresentation vector ssrnum algC algnum.
-From mathcomp
-Require Import classfun character inertia vcharacter integral_char.
-From odd_order
-Require Import PFsection1 PFsection2 PFsection3 PFsection4 PFsection5.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div choice fintype tuple finfun bigop prime finset.
+From mathcomp Require Import order.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import ssralg zmodp poly ssrnum archimedean matrix.
+From mathcomp Require Import mxalgebra vector.
+From mathcomp Require Import cyclic center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal hall frobenius.
+From mathcomp Require Import algC algnum.
+From mathcomp Require Import mxrepresentation classfun character integral_char.
+From mathcomp Require Import inertia vcharacter.
+From odd_order Require Import PFsection1 PFsection2 PFsection3 PFsection4.
+From odd_order Require Import PFsection5.
 
 (******************************************************************************)
 (* This file covers Peterfalvi, Section 6:                                    *)
@@ -105,10 +102,10 @@ have [phi SAphi phi1] := exists_linInd ltAK nsAK.
 have{SAphi} S1phi: phi \in S1 by rewrite mem_cat SAphi orbT.
 apply: (extend_coherent scohS) ccsS1S S1phi Spsi S1'psi _.
 have{SBpsi} /seqIndP[i /setDP[kBi _] {psi}->] := SBpsi; rewrite inE in kBi.
-rewrite {phi}phi1 cfInd1 // dvdC_mulr //; last by rewrite CintE Cnat_irr1.
+rewrite {phi}phi1 cfInd1 // dvdC_mulr //; last by rewrite intrE Cnat_irr1.
 split; rewrite // big_cat sum_seqIndD_square // big_seq ltr_wpDl //=.
   apply/sumr_ge0=> xi S2xi; rewrite divr_ge0 ?cfnorm_ge0 ?exprn_ge0 //.
-  by rewrite Cnat_ge0 // (Cnat_seqInd1 (sS1S _ _)) // mem_cat S2xi.
+  by rewrite natr_ge0 // (Cnat_seqInd1 (sS1S _ _)) // mem_cat S2xi.
 rewrite mulrC ltr_pM2l ?gt0CiG //; apply: le_lt_trans lb_KA.
 by rewrite -!mulrA !ler_wpM2l ?ler0n // (irr1_bound_quo nsBC).
 Qed.
@@ -290,7 +287,7 @@ rewrite -(isog_pgroup p (quotient1_isog K)) => pK ab'K.
 set e := #|L : K| => not_e_dv_p1; have e_gt0: (e > 0)%N by apply: indexg_gt0.
 have ntK: K != 1%G by apply: contraNneq ab'K => ->; rewrite quotient1 abelian1.
 have{ab'K ntK} [p_pr p_dv_K _] := pgroup_pdiv pK ntK.
-set Y := calX; pose d (xi : 'CF(L)) := logn p (truncC (xi 1%g) %/ e).
+set Y := calX; pose d (xi : 'CF(L)) := logn p (Num.trunc (xi 1%g) %/ e).
 have: cfConjC_closed Y by apply: cfAut_seqInd.
 have: perm_eq (Y ++ [::]) calX by rewrite cats0.
 have: {in Y & [::], forall xi1 xi2, d xi1 <= d xi2}%N by [].
@@ -307,8 +304,8 @@ case homoY: (constant [seq xi 1%g | xi : 'CF(L) <- Y]).
   exact: uniform_degree_coherence (subset_subcoherent scohS _) homoY.
 have Ndg: {in calX, forall xi : 'CF(L), xi 1%g = (e * p ^ d xi)%:R}.
   rewrite /d => _ /seqIndP[i _ ->]; rewrite cfInd1 // -/e.
-  have:= dvd_irr1_cardG i; have /CnatP[n ->] := Cnat_irr1 i.
-  rewrite -natrM natCK dvdC_nat mulKn // -p_part => dv_n_K.
+  have:= dvd_irr1_cardG i; have /natrP[n ->] := Cnat_irr1 i.
+  rewrite -natrM natrK dvdC_nat mulKn // -p_part => dv_n_K.
   by rewrite part_pnat_id // (pnat_dvd dv_n_K).
 have [chi Ychi leYchi]: {chi | chi \in Y & {in Y, forall xi, d xi <= d chi}%N}.
   have [/eqP/nilP Y0 | ntY] := posnP (size Y); first by rewrite Y0 in homoY.
@@ -330,7 +327,7 @@ have Xchi := sYX _ Ychi; have defY: perm_eq [:: chi, chi^*%CF & Y'] Y.
   by rewrite mem_rem_uniq ?inE ?ccY // (seqInd_conjC_neq _ _ _ Xchi).
 apply: perm_coherent (defY) _.
 have d_chic: d chi^*%CF = d chi.
-  by rewrite /d cfunE/= conj_Cnat // (Cnat_seqInd1 Xchi).
+  by rewrite /d cfunE/= conj_natr // (Cnat_seqInd1 Xchi).
 have /and3P[uniqY' Y'xi1 notY'chi]: [&& uniq Y', xi1 \in Y' & chi \notin Y'].
   rewrite !(inE, mem_rem_uniq) ?rem_uniq // Yxi1 eqxx andbF !andbT -negb_or.
   by apply: contraL lt_xi1_chi => /pred2P[] ->; rewrite ?d_chic ltnn.
@@ -374,9 +371,9 @@ rewrite -expnM Gauss_dvd ?coprimeXl ?coprimeXr {coep}// dvdn_mulr //=.
 have /dvdn_addl <-: p ^ (d chi * 2) %| e ^ 2 * sum_p2d X''.
   rewrite big_distrr big_seq dvdn_sum //= => xi /le_chi_X'' le_chi_xi.
   by rewrite dvdn_mull // dvdn_exp2l ?leq_pmul2r.
-rewrite -mulnDr -big_cat (perm_big _ defX) -(natCK (e ^ 2 * _)) /=.
+rewrite -mulnDr -big_cat (perm_big _ defX) -(@natrK algC (e ^ 2 * _)) /=.
 rewrite -def_sum_xi1 // /sum_xi1 sum_seqIndD_square ?normal1 ?sub1G //.
-rewrite indexg1 -(natrB _ (cardG_gt0 Z)) -natrM natCK.
+rewrite indexg1 -(natrB _ (cardG_gt0 Z)) -natrM natrK.
 rewrite -(Lagrange_index sKL sZK) mulnAC dvdn_mull //.
 have /p_natP[k defKZ]: p.-nat #|K : Z| by rewrite (pnat_dvd (dvdn_indexg K Z)).
 rewrite defKZ dvdn_exp2l // -(leq_exp2l _ _ (prime_gt1 p_pr)) -{k}defKZ.
@@ -396,7 +393,7 @@ Lemma constant_irr_mod_TI_Sylow Z L P p i :
      {in Z^# &, forall x y, #|'C_L[x]| = #|'C_L[y]| } ->
      let phi := 'chi[G]_i in
      {in Z^# &, forall x y, phi x = phi y} ->
-   {in Z^#, forall x, phi x \in Cint /\ (#|P| %| phi x - phi 1%g)%C}.
+   {in Z^#, forall x, phi x \in Num.int /\ (#|P| %| phi x - phi 1%g)%C}.
 Proof.
 move=> sylP oddL tiP [/andP[sZL nZL] ntZ sZ_ZP] prZL; move: i.
 pose a := @gring_classM_coef _ G; pose C (i : 'I_#|classes G|) := enum_val i.
@@ -458,22 +455,22 @@ pose i0 := inC _ (group1 G); pose i1 := inC z Gz; pose i2 := inC _ (groupVr Gz).
 suffices Ea2 l (phi := 'chi[G]_l) (kerZphi : kerZ l):
   (phi z *+ a2 i1 i1 == phi 1%g + phi z *+ a2 i1 i2 %[mod #|P|])%A.
 - move=> l phi kerZphi.
-  have Zphi1: phi 1%g \in Cint by rewrite irr1_degree rpred_nat.
+  have Zphi1: phi 1%g \in Num.int by rewrite irr1_degree rpred_nat.
   have chi0 x: x \in Z -> 'chi[G]_0 x = 1.
     by rewrite irr0 cfun1E => /(subsetP sZG) ->.
   have: kerZ 0 by move=> x y /setD1P[_ Zx] /setD1P[_ Zy]; rewrite !chi0.
   move/Ea2/(eqAmodMl (Aint_irr l z)); rewrite !{}chi0 // -/phi eqAmod_sym.
   rewrite mulrDr mulr1 !mulr_natr => /eqAmod_trans/(_ (Ea2 l kerZphi)).
-  rewrite eqAmodDr -/phi eqAmod_rat ?rpred_nat ?(rpred_Cint _ Zphi1) //.
+  rewrite eqAmodDr -/phi eqAmod_rat ?rpred_nat ?(rpred_int_num _ Zphi1) //.
     move=> PdvDphi; split; rewrite // -[phi z](subrK (phi 1%g)) rpredD //.
     by have /dvdCP[b Zb ->] := PdvDphi; rewrite rpredM ?rpred_nat.
   have nz_Z1: #|Z^#|%:R != 0 :> algC.
     by rewrite pnatr_eq0 cards_eq0 setD_eq0 subG1.
   rewrite -[phi z](mulfK nz_Z1) rpred_div ?rpred_nat // mulr_natr.
-  rewrite -(rpredDl _ (rpred_Cint _ Zphi1)) //.
+  rewrite -(rpredDl _ (rpred_int_num _ Zphi1)) //.
   rewrite -[_ + _](mulVKf (neq0CG Z)) rpredM ?rpred_nat //.
   have: '['Res[Z] phi, 'chi_0] \in Crat.
-    by rewrite rpred_Cnat ?Cnat_cfdot_char ?cfRes_char ?irr_char.
+    by rewrite rpred_nat_num ?Cnat_cfdot_char ?cfRes_char ?irr_char.
   rewrite irr0 cfdotE (big_setD1 _ (group1 Z)) cfun1E cfResE ?group1 //=.
   rewrite rmorph1 mulr1; congr (_ * (_ + _) \in Crat).
   rewrite -sumr_const; apply: eq_bigr => x Z1x; have [_ Zx] := setD1P Z1x.
@@ -716,13 +713,14 @@ have oYtau: orthonormal (map tau1 Y) by apply: map_orthonormal.
 have [[_ oYY] [_ oYYt]] := (orthonormalP oY, orthonormalP oYtau).
 have [eta1 Yeta1]: {eta1 | eta1 \in Y} by apply: seqIndD_nonempty.
 pose m : algC := (size Y)%:R; pose m_ub2 a := (a - 1) ^+ 2 + (m - 1) * a ^+ 2.
-have m_ub2_lt2 a: a \in Cint -> m_ub2 a < 2%:R -> a = 0 \/ a = 1 /\ size Y = 2%N.
+have m_ub2_lt2 a: a \in Num.int -> m_ub2 a < 2%:R ->
+                  a = 0 \/ a = 1 /\ size Y = 2%N.
   move=> Za ub_a; have [|nza] := eqVneq a 0; [by left | right].
   have ntY: (1 < size Y)%N by apply: seqInd_nontrivial Yeta1.
   have m1_ge1: 1 <= m - 1 by rewrite lerBrDr (ler_nat _ 2).
   have a1: a = 1.
     apply: contraFeq (lt_geF ub_a); rewrite -subr_eq0 /m_ub2 => nz_a1.
-    by rewrite lerD ?(mulr_ege1 m1_ge1) // sqr_Cint_ge1 ?rpredB /=.
+    by rewrite lerD ?(mulr_ege1 m1_ge1) // sqr_intr_ge1 ?rpredB /=.
   rewrite /m_ub2 a1 subrr expr0n add0r expr1n mulr1 in ub_a.
   rewrite ltrBlDr -mulrSr ltr_nat ltnS in ub_a.
   by split; last apply/anti_leq/andP.
@@ -766,26 +764,26 @@ have{odd_frobL1} caseA_cohXY: caseA -> coherent (X ++ Y) L^# tau.
     rewrite !cfInd1 // !De -!natrM dvdC_nat dvdn_pmul2l //.
     by rewrite dvdn_Pexp2l ?min_i1 ?prime_gt1.
   have nz_xi1_1: xi1 1%g != 0 by apply: seqInd1_neq0 Xxi1.
-  pose d (xi : 'CF(L)) : algC := (truncC (xi 1%g / xi1 1%g))%:R.
+  pose d (xi : 'CF(L)) : algC := (Num.trunc (xi 1%g / xi1 1%g))%:R.
   have{dvd_xi1_1} def_d xi: xi \in X -> xi 1%g = d xi * xi1 1%g.
-    rewrite /d => Xxi; have Xge0 := Cnat_ge0 (Cnat_seqInd1 (_ : _ \in X)).
-    by have /dvdCP_nat[||q ->] := dvd_xi1_1 xi Xxi; rewrite ?Xge0 ?mulfK ?natCK.
-  have d_xi1: d xi1 = 1 by rewrite /d divff ?truncC1.
+    rewrite /d => Xxi; have Xge0 := natr_ge0 (Cnat_seqInd1 (_ : _ \in X)).
+    by have /dvdCP_nat[||q ->] := dvd_xi1_1 xi Xxi; rewrite ?Xge0 ?mulfK ?natrK.
+  have d_xi1: d xi1 = 1 by rewrite /d divff ?trunc1.
   have [_ [Itau /(_ _ _)/zcharW-Ztau] _ _ _] := scohS.
   have o_tauXY: orthogonal (map tau2 X) (map tau1 Y).
     exact: (coherent_ortho scohS).
-  have [a Na xi1_1]: exists2 a, a \in Cnat & xi1 1%g = a * #|W1|%:R.
+  have [a Na xi1_1]: exists2 a, a \in Num.nat & xi1 1%g = a * #|W1|%:R.
     have [i _ ->] := seqIndP Xxi1; rewrite cfInd1 // -oW1 mulrC.
     by exists ('chi_i 1%g); first apply: Cnat_irr1.
   pose psi1 := xi1 - a *: eta1.
   have Zpsi1: psi1 \in 'Z[S, L^#].
     rewrite zcharD1E !cfunE (uniY _ Yeta1) -xi1_1 subrr eqxx andbT.
-    by rewrite rpredB ?rpredZ_Cnat ?mem_zchar ?(sXS _ Xxi1) // sYS.
+    by rewrite rpredB ?rpredZ_nat ?mem_zchar ?(sXS _ Xxi1) // sYS.
   have [Y1 dY1 [X1 [dX1 _ oX1tauY]]] := orthogonal_split (map tau1 Y)(tau psi1).
-  have{dX1 Y1 dY1 oYtau} [b Zb tau_psi1]: {b | b \in Cint &
+  have{dX1 Y1 dY1 oYtau} [b Zb tau_psi1]: {b | b \in Num.int &
     tau psi1 = X1 - a *: tau1 eta1 + b *: (\sum_(eta <- Y) tau1 eta)}.
   - exists ('[tau psi1, tau1 eta1] + a).
-      by rewrite rpredD ?Cint_cfdot_vchar ?Cint_Cnat ?Ztau ?Ztau1 ?mem_zchar.
+      by rewrite rpredD ?Cint_cfdot_vchar ?intr_nat ?Ztau ?Ztau1 ?mem_zchar.
     rewrite [LHS]dX1 addrC -addrA; congr (_ + _).
     have{dY1} [_ -> ->] := orthonormal_span oYtau dY1.
     transitivity (\sum_(xi <- map tau1 Y) '[tau psi1, xi] *: xi).
@@ -821,11 +819,11 @@ have{odd_frobL1} caseA_cohXY: caseA -> coherent (X ++ Y) L^# tau.
   have Eba: '[psi, psi1] = b - a.
     rewrite cfdotC cfdot_Res_r -/tau tau_psi1 cfdotDl cfdotBl cfdotZl.
     rewrite (orthoPl oX1tauY) 1?oYYt ?map_f // eqxx sub0r addrC mulr1 rmorphB.
-    by rewrite scaler_sumr cfproj_sum_orthonormal // aut_Cint // aut_Cnat.
+    by rewrite scaler_sumr cfproj_sum_orthonormal // aut_intr // aut_natr.
   have{Eba oxi2X} Ebc: (a %| b - c)%C.
     rewrite -[b](subrK a) -Eba cfdotBr {1}Dpsi cfdotDl cfdotZl.
     rewrite cfproj_sum_orthonormal // (orthoPl oxi2X) // addr0 d_xi1 mulr1.
-    rewrite addrC -addrA addKr addrC rpredB ?dvdC_refl //= cfdotZr aut_Cnat //.
+    rewrite addrC -addrA addKr addrC rpredB ?dvdC_refl //= cfdotZr aut_natr //.
     by rewrite dvdC_mulr // Cint_cfdot_vchar ?(seqInd_vcharW Yeta1).
   have DsumXd: sumXd = (xi1 1%g)^-1 *: (cfReg L - cfReg (L / Z) %% Z)%CF.
     apply/(canRL (scalerK nz_xi1_1))/(canRL (addrK _)); rewrite !cfReg_sum.
@@ -863,7 +861,7 @@ have{odd_frobL1} caseA_cohXY: caseA -> coherent (X ++ Y) L^# tau.
   have{c Ebc dv_ac} /dvdCP[q Zq Db]: (a %| b)%C by rewrite rpredBr in Ebc.
   have norm_psi1: '[psi1] = 1 + a ^+ 2.
     rewrite cfnormBd; last by rewrite cfdotZr (orthogonalP oXY) ?mulr0.
-    by rewrite cfnormZ norm_Cnat // oXX // oYY // !eqxx mulr1.
+    by rewrite cfnormZ norm_natr // oXX // oYY // !eqxx mulr1.
   have{Zb oYYt} norm_tau_psi1: '[tau psi1] = '[X1] + a ^+ 2 * m_ub2 q.
     rewrite tau_psi1 -addrA cfnormDd /m_ub2; last first.
       rewrite addrC big_seq (span_orthogonal oX1tauY) ?memv_span1 //.
@@ -871,17 +869,17 @@ have{odd_frobL1} caseA_cohXY: caseA -> coherent (X ++ Y) L^# tau.
     congr (_ + _); transitivity (b ^+ 2 * m + a ^+ 2 - a * b *+ 2); last first.
       rewrite [RHS]mulrC [in RHS]addrC mulrBl sqrrB1 !addrA mulrDl !mul1r subrK.
       by rewrite mulrBl [m * _]mulrC mulrnAl [in RHS]mulrAC Db exprMn (mulrCA a) addrAC.
-    rewrite addrC cfnormB !cfnormZ Cint_normK ?norm_Cnat // cfdotZr.
+    rewrite addrC cfnormB !cfnormZ intr_normK ?norm_natr // cfdotZr.
     rewrite cfnorm_map_orthonormal // -/m linear_sum cfproj_sum_orthonormal //.
-    by rewrite oYYt ?map_f // eqxx mulr1 rmorphM/= conjCK aut_Cnat ?aut_Cint.
+    by rewrite oYYt ?map_f // eqxx mulr1 rmorphM/= conjCK aut_natr ?aut_intr.
   have{norm_tau_psi1} mq2_lt2: m_ub2 q < 2%:R.
     suffices a2_gt1: a ^+ 2 > 1.
       have /ltr_pM2l <-: a ^+ 2 > 0 by apply: lt_trans a2_gt1.
       rewrite -(ltrD2l '[X1]) -norm_tau_psi1 ltr_wpDl ?cfnorm_ge0 //.
       by rewrite Itau // mulr_natr norm_psi1 ltrD2r.
     suffices a_neq1: a != 1.
-      rewrite expr_gt1 ?Cnat_ge0 // lt_neqAle eq_sym a_neq1.
-      by rewrite -(norm_Cnat Na) norm_Cint_ge1 ?Cint_Cnat.
+      rewrite expr_gt1 ?natr_ge0 // lt_neqAle eq_sym a_neq1.
+      by rewrite -(norm_natr Na) norm_intr_ge1 ?intr_nat.
     have /seqIndP[i1 /setDP[_ not_kerH'i1] Dxi1] := Xxi1.
     apply: contraNneq not_kerH'i1 => a_eq1; rewrite inE (subset_trans sZH') //.
     rewrite -lin_irr_der1 qualifE/= irr_char /= -(inj_eq (mulfI (neq0CiG L H))).
@@ -909,27 +907,27 @@ have{odd_frobL1} caseA_cohXY: caseA -> coherent (X ++ Y) L^# tau.
   have n1X1: '[X1] = 1.
     rewrite -(canLR (addrK _) norm_psi1) -Itau // tau_psi1.
     rewrite cfnormBd; last by rewrite cfdotZr (orthoPl oX1tauY) ?map_f ?mulr0.
-    by rewrite cfnormZ norm_Cnat // Itau1 ?mem_zchar ?oYY // eqxx mulr1 addrK.
+    by rewrite cfnormZ norm_natr // Itau1 ?mem_zchar ?oYY // eqxx mulr1 addrK.
   without loss{Itau2 Ztau2 Dtau2} defX1: tau2 cohX o_tauXY / X1 = tau2 xi1.
     move=> IH; have ZX: {subset X <= 'Z[X]} by apply: seqInd_zcharW.
     have dirrXtau xi: xi \in X -> tau2 xi \in dirr G.
       by move=> Xxi; rewrite dirrE Ztau2 1?Itau2 ?ZX //= oXX ?eqxx.
     have dirrX1: X1 \in dirr G.
       rewrite dirrE n1X1 eqxx -(canLR (subrK _) tau_psi1).
-      by rewrite rpredD ?rpredZ_Cnat ?(zcharW (Ztau _ _)) ?Ztau1 ?seqInd_zcharW.
+      by rewrite rpredD ?rpredZ_nat ?(zcharW (Ztau _ _)) ?Ztau1 ?seqInd_zcharW.
     have{Zxi1Xd} oXdX1 xi: xi \in X -> xi != xi1 ->
       '[d xi *: tau2 xi1 - tau2 xi, X1] = d xi.
     - move=> Xxi xi1'xi; have ZXxi := Zxi1Xd xi Xxi.
       rewrite -(canLR (subrK _) tau_psi1) cfdotDr addrC.
       rewrite (span_orthogonal o_tauXY) ?rpredB ?rpredZ ?memv_span ?map_f //.
-      rewrite add0r -opprB cfdotNl -{1}raddfZ_Cnat ?Cnat_nat // -raddfB.
+      rewrite add0r -opprB cfdotNl -{1}raddfZ_nat ?natr_nat // -raddfB.
       rewrite Dtau2 // Itau ?cfdotBr ?opprB //; last exact: zchar_subset ZXxi.
       rewrite (span_orthogonal oXY) ?rpredB ?rpredZ ?memv_span // sub0r.
       by rewrite cfdotBl cfdotZl opprB !oXX // eqxx mulr1 mulrb ifN ?subr0.
     pose xi3 := xi1^*%CF; have Xxi3: xi3 \in X by apply: ccX.
     have xi1'3: xi3 != xi1 by rewrite (hasPn nrS) ?sXS.
     have [| defX1]: X1 = tau2 xi1 \/ X1 = - tau2 xi3; first 2 [exact : IH].
-      have d_xi3: d xi3 = 1 by rewrite /d cfunE/= conj_Cnat ?(Cnat_seqInd1 Xxi1).
+      have d_xi3: d xi3 = 1 by rewrite /d cfunE/= conj_natr ?(Cnat_seqInd1 Xxi1).
       have:= oXdX1 xi3 Xxi3 xi1'3; rewrite d_xi3 scale1r.
       by apply: cfdot_add_dirr_eq1; rewrite // ?rpredN dirrXtau.
     have szX2: (size X <= 2)%N.
@@ -940,9 +938,9 @@ have{odd_frobL1} caseA_cohXY: caseA -> coherent (X ++ Y) L^# tau.
     apply: (IH _ (dual_coherence scohX cohX szX2)) defX1.
     apply/orthogonalP=> _ psi2 /mapP[xi Xxi -> /=] Ytau_psi2.
     by rewrite cfdotNl (orthogonalP o_tauXY) ?oppr0 // map_f ?ccX.
-  rewrite -raddfZ_Cnat // defX1 in tau_psi1.
+  rewrite -raddfZ_nat // defX1 in tau_psi1.
   apply: (bridge_coherent scohS ccsXS cohX ccsYS cohY X'Y) tau_psi1.
-  by rewrite (zchar_on Zpsi1) rpredZ_Cnat ?mem_zchar.
+  by rewrite (zchar_on Zpsi1) rpredZ_nat ?mem_zchar.
 have{caseA_cohXY Itau1 Ztau1 Dtau1 oYYt} cohXY: coherent (X ++ Y) L^# tau.
   have [in_caseA | in_caseB] := boolP caseA; first exact: caseA_cohXY.
   have defZ: Z = W2 by rewrite /Z ifN.
@@ -969,7 +967,7 @@ have{caseA_cohXY Itau1 Ztau1 Dtau1 oYYt} cohXY: coherent (X ++ Y) L^# tau.
     rewrite -[cfAut u _](subrK eta) -opprB addrC raddfB !cfunE -[RHS]subr0.
     congr (_ - _); rewrite Dtau1 ?zcharD1_seqInd ?seqInd_sub_aut_zchar //.
     rewrite Dade_id; last by rewrite !inE -cycle_eq1 -cycle_subG -cycZ ntZ.
-    rewrite !cfunE/= cfker1 ?aut_Cnat ?subrr ?(Cnat_seqInd1 Yeta) //.
+    rewrite !cfunE/= cfker1 ?aut_natr ?subrr ?(Cnat_seqInd1 Yeta) //.
     have [j /setDP[kerH'j _] Deta] := seqIndP Yeta; rewrite inE in kerH'j.
     by rewrite -cycle_subG -cycZ (subset_trans sZH') // Deta sub_cfker_Ind_irr.
   have [_ [Itau /(_ _ _)/zcharW-Ztau] oSS _ _] := scohS.
@@ -998,7 +996,7 @@ have{caseA_cohXY Itau1 Ztau1 Dtau1 oYYt} cohXY: coherent (X ++ Y) L^# tau.
         by rewrite -Epsi1 !cfunE !psi1Z.
       by rewrite -Epsi1 !cfunE -mulrBr rpredMsign psi1Z.
     pose x1 := '[eta1, 'Res psi1]; pose x := x0 + 1 - x1.
-    have Zx: x \in Cint.
+    have Zx: x \in Num.int.
       rewrite rpredB ?rpredD //= Cint_cfdot_vchar // ?(seqInd_vcharW Yeta1) //.
       by rewrite cfRes_vchar // Ztau1 ?seqInd_zcharW.
     pose Y1 := - \sum_(eta <- Y) (x - (eta == eta1)%:R) *: tau1 eta.
@@ -1008,7 +1006,7 @@ have{caseA_cohXY Itau1 Ztau1 Dtau1 oYYt} cohXY: coherent (X ++ Y) L^# tau.
         by rewrite lin_irr_der1 (derG1P _) ?sub1G // cycZ cycle_abelian.
       have Xchi: 'Ind 'chi_i \in 'Z[X].
         rewrite -(cfIndInd _ sHL) // ['Ind[H] _]cfun_sum_constt linear_sum.
-        apply: rpred_sum => k k_i; rewrite linearZ rpredZ_Cint ?mem_zchar //=.
+        apply: rpred_sum => k k_i; rewrite linearZ rpredZ_int ?mem_zchar //=.
           by rewrite Cint_cfdot_vchar_irr // cfInd_vchar ?irr_vchar.
         rewrite mem_seqInd ?normal1 // !inE sub1G andbT.
         by rewrite -(sub_cfker_constt_Ind_irr k_i) // subGcfker.
@@ -1025,7 +1023,7 @@ have{caseA_cohXY Itau1 Ztau1 Dtau1 oYYt} cohXY: coherent (X ++ Y) L^# tau.
         rewrite -(big_tuple _ _ _ xpredT (fun xi : 'CF(Z) => xi 1%g *: xi)).
         rewrite cfproj_sum_orthonormal ?irr_orthonormal ?mem_irr // lin_i mulr1.
         rewrite -irr0 cfdot_irr (negPf nzi) mulr0 addr0.
-        by rewrite aut_Cint // Dx0 rpredM ?rpred_nat.
+        by rewrite aut_intr // Dx0 rpredM ?rpred_nat.
       exists (tau (gamma i) + #|H : Z|%:R *: Y1); last by rewrite addrK.
       apply/orthoPl=> _ /mapP[eta Yeta ->].
       rewrite scalerN cfdotBl cfdotZl cfproj_sum_orthonormal // [x]addrAC.
@@ -1065,10 +1063,10 @@ have{caseA_cohXY Itau1 Ztau1 Dtau1 oYYt} cohXY: coherent (X ++ Y) L^# tau.
         rewrite (span_orthogonal oX1Y) ?memv_span1 ?rpredZ // rpredN big_seq.
         by apply/rpred_sum => eta Yeta; rewrite rpredZ ?memv_span ?map_f.
       rewrite cfnormN cfnorm_sum_orthonormal // (big_rem eta1) //= eqxx.
-      congr (_ + _ < _); first by rewrite Cint_normK 1?rpredB ?rpred1.
+      congr (_ + _ < _); first by rewrite intr_normK 1?rpredB ?rpred1.
       transitivity (\sum_(eta <- rem eta1 Y) x ^+ 2).
         rewrite rem_filter // !big_filter; apply/eq_bigr => eta /negPf->.
-        by rewrite subr0 Cint_normK.
+        by rewrite subr0 intr_normK.
       rewrite big_const_seq count_predT // -Monoid.iteropE -[LHS]mulr_natl.
       by rewrite /m (perm_size (perm_to_rem Yeta1)) /= mulrSr addrK.
     have [x_eq0 | [x_eq1 szY2]] := m_ub2_lt2 x Zx ub_xm.
@@ -1093,14 +1091,14 @@ have{caseA_cohXY Itau1 Ztau1 Dtau1 oYYt} cohXY: coherent (X ++ Y) L^# tau.
     by rewrite rpredN mem_zchar ?map_f ?ccY.
   have spanYtau1 := zchar_span YtauY1.
   have norm_eta1: '[eta1] = 1 by rewrite oYY ?eqxx.
-  have /all_sig2[a Za Dxa] xi: {a | a \in Cnat
+  have /all_sig2[a Za Dxa] xi: {a | a \in Num.nat
                   & xi \in X -> xi 1%g = a * #|W1|%:R
                     /\ (exists2 X1 : 'CF(G), orthogonal X1 (map tau1 Y)
                               & tau (xi - a *: eta1) = X1 - a *: Y1)}.
   - case Xxi: (xi \in X); last by exists 0; rewrite ?rpred0.
     have /sig2_eqW[k /setDP[_ kerZ'k] def_xi] := seqIndP Xxi.
     rewrite inE in kerZ'k.
-    pose a := 'chi_k 1%g; have Na: a \in Cnat by apply: Cnat_irr1.
+    pose a := 'chi_k 1%g; have Na: a \in Num.nat by apply: Cnat_irr1.
     have Dxi1: xi 1%g = a * #|W1|%:R by rewrite mulrC oW1 def_xi cfInd1.
     exists a => // _; split=> //.
     have [i0 nzi0 Res_k]: exists2 i, i != 0 & 'Res[Z] 'chi_k = a *: 'chi_i.
@@ -1118,12 +1116,13 @@ have{caseA_cohXY Itau1 Ztau1 Dtau1 oYYt} cohXY: coherent (X ++ Y) L^# tau.
     have defIphi: 'Ind phi = \sum_(i in rp) a_ i *: 'chi_i.
       exact: cfun_sum_constt.
     have a_k: a_ k = a.
-      by rewrite /a_ -cfdot_Res_r Res_k cfdotZr cfnorm_irr mulr1 conj_Cnat.
+      by rewrite /a_ -cfdot_Res_r Res_k cfdotZr cfnorm_irr mulr1 conj_natr.
     have rp_k: k \in rp by rewrite inE ['[_, _]]a_k irr1_neq0.
     have resZr i: i \in rp -> 'Res[Z] 'chi_i = a_ i *: phi.
       rewrite constt_Ind_Res -/phi => /Clifford_Res_sum_cfclass-> //.
-      have Na_i: a_ i \in Cnat by rewrite Cnat_cfdot_char ?cfInd_char ?irr_char.
-      rewrite -/phi cfdot_Res_l cfdotC conj_Cnat {Na_i}//; congr (_ *: _).
+      have Na_i: a_ i \in Num.nat.
+        by rewrite Cnat_cfdot_char ?cfInd_char ?irr_char.
+      rewrite -/phi cfdot_Res_l cfdotC conj_natr {Na_i}//; congr (_ *: _).
       have <-: 'I_H['Res[Z] 'chi_k] = H.
         apply/eqP; rewrite eqEsubset subsetIl.
         by apply: subset_trans (sub_inertia_Res _ _); rewrite ?sub_Inertia.
@@ -1163,11 +1162,11 @@ have{caseA_cohXY Itau1 Ztau1 Dtau1 oYYt} cohXY: coherent (X ++ Y) L^# tau.
     have oRY i: i \in rp -> orthogonal (R (chi i)) (map tau1 Y).
       move/Xchi=> Xchi_i; rewrite orthogonal_sym.
       by rewrite (coherent_ortho_supp scohS) // ?sXS // (contraL (X'Y _)).
-    have Za_ i: a_ i \in Cint.
+    have Za_ i: a_ i \in Num.int.
       by rewrite Cint_cfdot_vchar_irr // cfInd_vchar ?irr_vchar.
     have Zeta1: eta1 \in 'Z[irr L] := seqInd_vcharW Yeta1.
     have Ztau_alpha i: tau (alpha i) \in 'Z[irr G].
-      by rewrite !(cfInd_vchar, rpredB) ?irr_vchar ?rpredZ_Cint.
+      by rewrite !(cfInd_vchar, rpredB) ?irr_vchar ?rpredZ_int.
     have /all_tag2[X1 R_X1 /all_tag2[b Rb /all_sig2[Z1 oZ1R]]] i:
          {X1 : 'CF(G) & i \in rp -> X1 \in 'Z[R (chi i)]
        & {b : algC & i \in rp -> b \is Creal
@@ -1179,10 +1178,10 @@ have{caseA_cohXY Itau1 Ztau1 Dtau1 oYYt} cohXY: coherent (X ++ Y) L^# tau.
         have [_ _ _ Rok _] := scohS => /Xchi/sXS/Rok[ZR oRR _].
         have [_ -> ->] := orthonormal_span oRR dX1.
         rewrite big_seq rpred_sum // => aa Raa.
-        rewrite rpredZ_Cint ?mem_zchar // -(canLR (addrK _) dXYZ) cfdotBl.
+        rewrite rpredZ_int ?mem_zchar // -(canLR (addrK _) dXYZ) cfdotBl.
         by rewrite (orthoPl oYZ1R) // subr0 Cint_cfdot_vchar ?(ZR aa).
       pose b := - '[YZ1, Y1]; exists b => [rp_i|].
-        rewrite Creal_Cint // rpredN -(canLR (addKr _) dXYZ) cfdotDl.
+        rewrite Rreal_int // rpredN -(canLR (addKr _) dXYZ) cfdotDl.
         rewrite (span_orthogonal (oRY i rp_i)) ?rpredN ?(zchar_span YtauY1) //.
         rewrite add0r Cint_cfdot_vchar // (zchar_trans_on _ YtauY1) //.
         by move=> _ /mapP[eta Yeta ->]; rewrite Ztau1 ?mem_zchar.
@@ -1197,12 +1196,12 @@ have{caseA_cohXY Itau1 Ztau1 Dtau1 oYYt} cohXY: coherent (X ++ Y) L^# tau.
            [/\ '[X1 i] = '[chi i], '[b i *: Y1 - Z1 i] = '[a_ i *: eta1]
              & exists2 E, subseq E (R (chi i)) & X1 i = \sum_(aa <- E) aa]].
     + move=> rp_i; apply: (subcoherent_norm scohS) (erefl _) _.
-      * rewrite sXS ?Xchi ?rpredZ_Cint /orthogonal //; split=> //=.
+      * rewrite sXS ?Xchi ?rpredZ_int /orthogonal //; split=> //=.
         by rewrite !cfdotZr !(orthogonalP oXY) ?mulr0 ?eqxx ?ccX // Xchi.
       * have [[/(_ _ _)/char_vchar-Z_S _ _] IZtau _ _ _] := scohS.
         apply: sub_iso_to IZtau; [apply: zchar_trans_on | exact: zcharW].
         apply/allP; rewrite /= zchar_split (cfun_onS (setSD _ sHL)) ?Aalpha //.
-        rewrite rpredB ?rpredZ_Cint ?mem_zchar ?(sYS eta1) // ?sXS ?Xchi //=.
+        rewrite rpredB ?rpredZ_int ?mem_zchar ?(sYS eta1) // ?sXS ?Xchi //=.
         by rewrite sub_aut_zchar ?zchar_onG ?mem_zchar ?sXS ?ccX ?Xchi.
       suffices oYZ_R: orthogonal (b i *: Y1 - Z1 i) (R (chi i)).
         rewrite opprD opprK addrA -defXbZ cfdotC.
@@ -1222,10 +1221,10 @@ have{caseA_cohXY Itau1 Ztau1 Dtau1 oYYt} cohXY: coherent (X ++ Y) L^# tau.
         by rewrite (span_orthogonal (oZ1R i _)) ?raddf0 ?memv_span1 ?spanR_X1.
       have Salpha: alpha i \in 'Z[S, L^#].
         rewrite zcharD1_seqInd // zchar_split Aalpha // andbT.
-        by rewrite rpredB ?rpredZ_Cint ?mem_zchar ?(sYS eta1) ?sXS ?Xchi.
+        by rewrite rpredB ?rpredZ_int ?mem_zchar ?(sYS eta1) ?sXS ?Xchi.
       rewrite opprD opprK addrA -defXbZ ?Itau //.
       rewrite cfnormBd; last by rewrite cfdotZr (orthogonalP oXY) ?mulr0 ?Xchi.
-      rewrite cfnormZ Cint_normK ?(oYY eta1) // eqxx mulr1 lerD2r.
+      rewrite cfnormZ intr_normK ?(oYY eta1) // eqxx mulr1 lerD2r.
       by have lbX1i: '[chi i] <= '[X1 i] by have [] := ub_alpha i rp_i.
     have{leba} eq_ab: {in rp, a_ =1 b}.
       move=> i rp_i; apply/eqP; rewrite -subr_eq0; apply/eqP.
@@ -1295,7 +1294,7 @@ have ltZH': Z \proper H'.
 have Seta1: eta1 \in S1 by rewrite !mem_cat Yeta1 !orbT.
 apply: (extend_coherent scohS ccsS1S Seta1) => {Seta1}//; split=> //.
   rewrite (uniY _ Yeta1) Dpsi cfInd1 // oW1 dvdC_mulr //.
-  by rewrite Cint_Cnat ?Cnat_irr1.
+  by rewrite intr_nat ?Cnat_irr1.
 rewrite !big_cat /= addrCA sum_seqIndD_square ?normal1 ?sub1G // ltr_pwDr //.
   have /irrY/irrP[j Deta1] := Yeta1; have [_ sS1S _] := ccsS1S.
   rewrite (big_rem eta1 Yeta1) addrCA -big_cat big_seq ltr_pwDl //=.

--- a/theories/PFsection7.v
+++ b/theories/PFsection7.v
@@ -1,23 +1,19 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq path div choice fintype.
-From mathcomp
-Require Import tuple finfun bigop order prime ssralg poly finset center.
-From mathcomp
-Require Import fingroup morphism perm automorphism quotient action zmodp.
-From mathcomp
-Require Import gfunctor gproduct cyclic pgroup commutator nilpotent frobenius.
-From mathcomp
-Require Import matrix mxalgebra mxrepresentation.
-From odd_order
-Require Import BGsection3.
-From mathcomp
-Require Import vector ssrnum algC classfun character inertia vcharacter.
-From odd_order
-Require Import PFsection1 PFsection2 PFsection4 PFsection5 PFsection6.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div choice fintype tuple finfun bigop prime finset.
+From mathcomp Require Import order.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import ssralg zmodp poly ssrnum archimedean matrix.
+From mathcomp Require Import mxalgebra vector.
+From mathcomp Require Import cyclic center gfunctor commutator pgroup nilpotent.
+From mathcomp Require Import frobenius algC.
+From mathcomp Require Import mxrepresentation classfun character inertia.
+From mathcomp Require Import vcharacter.
+From odd_order Require Import BGsection3 PFsection1 PFsection2 PFsection4.
+From odd_order Require Import PFsection5 PFsection6.
 
 (******************************************************************************)
 (* This file covers Peterfalvi, Section 7:                                    *)
@@ -334,7 +330,7 @@ rewrite exchange_big; apply: eq_bigr => xi _; rewrite exchange_big /=.
 apply: eq_big_seq => mu Smu; have Tmu := sST mu Smu.
 rewrite /u eh (cfdotEr _ (seqInd_on nsHL Tmu)) (mulrC _^-1) -mulrBl mulrA.
 rewrite -mulr_suml -mulr_sumr (big_setD1 1%g (group1 H)) /=; congr (_ * _ * _).
-by rewrite addrC conj_Cnat ?addKr // (Cnat_seqInd1 Tmu).
+by rewrite addrC conj_natr ?addKr // (Cnat_seqInd1 Tmu).
 Qed.
 
 End InvDadeSeqInd.
@@ -353,7 +349,8 @@ Lemma Dade_Ind1_sub_lin (nu : {additive 'CF(L) -> 'CF(G)}) zeta :
   [/\ (*a1*) [/\ orthogonal calSnu 1%CF, '[beta, 1] = 1 & beta \in 'Z[irr G]],
       exists2 Gamma : 'CF(G),
       (*a2*) [/\ orthogonal calSnu Gamma, '[Gamma, 1] = 0
-             & exists2 a, a \in Cint & beta = 1 - nu zeta + a *: sumSnu + Gamma]
+             & exists2 a, a \in Num.int
+             & beta = 1 - nu zeta + a *: sumSnu + Gamma]
     & (*b*) e <= (h - 1) / 2%:R ->
             '[(nu zeta)^\rho] >= 1 - e / h /\ '[Gamma] <= e - 1
     & (*c*) {in irr G, forall chi : 'CF(G), orthogonal calSnu chi ->
@@ -385,7 +382,7 @@ have S_Se xi (Sxi : xi \in calS) := seqInd_sub_lin_vchar nsHL Szeta zeta1 Sxi.
 have oSnu1: orthogonal calSnu 1%CF.
   have dotSnu1 psi : psi \in calS -> '[nu psi, 1] = psi 1%g / e * '[nu zeta, 1].
     move=> Spsi; apply/eqP; rewrite -subr_eq0 -cfdotZl -cfdotBl.
-    rewrite -raddfZ_Cnat ?NatS1e // -raddfB; have Spi := S_Se _ Spsi.
+    rewrite -raddfZ_nat ?NatS1e // -raddfB; have Spi := S_Se _ Spsi.
     rewrite nu_tau ?defZS // invDade_reciprocity ?(zchar_on Spi) //.
     rewrite invDade_cfun1 (eq_cfdotr (zchar_on Spi) (eq_cfuni nsAL)).
     by rewrite cfdotBl cfdotZl !oS1 // mulr0 subr0.
@@ -411,14 +408,14 @@ have [a_ def_a defX] := orthogonal_span oSnuS SnuX.
 have{} def_a: {in calS, forall xi, a_ (nu xi) = '[beta, nu xi] / '[xi]}.
   move=> xi Sxi; rewrite (canRL (subrK 1) def_beta1) !cfdotDl def_a InuS //.
   by rewrite (cfdotC 1) (orthoPl oSnuG) ?(orthoPr oSnu1) ?map_f ?conjC0 ?addr0.
-pose a := '[beta, nu zeta] + 1; have Z1 := Cint1.
-have{Z1} Za: a \in Cint by rewrite rpredD ?Cint_cfdot_vchar // ZnuS.
+pose a := '[beta, nu zeta] + 1; have Z1 := int_num1.
+have{Z1} Za: a \in Num.int by rewrite rpredD ?Cint_cfdot_vchar //= ZnuS.
 have {a_ def_a} defX: X = - nu zeta + a *: sumSnu.
   rewrite linear_sum defX big_map !(perm_big _ defS) !big_cons /= addrCA.
   rewrite def_a // Nzeta1 !divr1 zeta1 divff // scalerDl !scale1r addrA.
   rewrite addrK; congr (_ + _); apply: eq_big_seq => xi /S1P[neq_xi Sxi].
   rewrite def_a // scalerA mulrA mulrDl mul1r; congr (_ / _ *: _).
-  rewrite mulrC -(conj_Cnat (NatS1e _ Sxi)) -cfdotZr -raddfZ_Cnat ?NatS1e //.
+  rewrite mulrC -(conj_natr (NatS1e _ Sxi)) -cfdotZr -raddfZ_nat ?NatS1e //.
   rewrite addrC; apply: canRL (subrK _) _; rewrite -!raddfB /= -/e.
   have Spi := S_Se xi Sxi; rewrite nu_tau ?defZS //.
   rewrite Dade_isometry ?(zchar_on Spi) // cfdotC cfdotBl cfdotZl !cfdotBr.
@@ -450,7 +447,7 @@ split=> // [ | chi /irrP[t def_chi] o_chiSnu].
     rewrite !addr0 c1 c2 Nzeta1 cfnorm_Ind_cfun1 // -/e Ind1H1 zeta1 conjC1.
     rewrite cfdotC (seqInd_ortho_Ind1 _ _ Szeta) // !kill0 sub0r !mulrN !mulr1.
     rewrite divr1 !mul1r !invfM mulrBr !mulrA !mulfK ?divfK // -/w.
-    rewrite aut_Cint // -[_ / h]mulrA -{1}[e^-1]mulr1 -2!mulrBr -/u -/v.
+    rewrite aut_intr // -[_ / h]mulrA -{1}[e^-1]mulr1 -2!mulrBr -/u -/v.
     by rewrite mulrC mulrA addrA (mulrC v) -[_ - _]addrA -opprD.
   have ->: '[Gamma] = e - 1 - h * (u * a ^+ 2 - v * a *+ 2).
     have /(canLR (addrK 1)) <-: '[beta] = e + 1.
@@ -461,14 +458,14 @@ split=> // [ | chi /irrP[t def_chi] o_chiSnu].
     rewrite cfnorm1 addrK def_beta1 (addrC X) cfnormDd; last first.
       by rewrite (span_orthogonal oSnuG) // memv_span ?mem_head.
     do 2!apply: canRL (addrK _) _; rewrite -addrA; congr (_ + _).
-    rewrite defX (addrC (- nu _)) cfnormB cfnormZ Cint_normK // InuS //.
+    rewrite defX (addrC (- nu _)) cfnormB cfnormZ intr_normK // InuS //.
     rewrite cfdotZl cfproj_sum_orthogonal // Nzeta1 zeta1 divff // divr1.
-    rewrite !mulr1 aut_Cint // mulrBr mulrDr mulVKf // addrAC.
+    rewrite !mulr1 aut_intr // mulrBr mulrDr mulVKf // addrAC.
     rewrite mulrA mulrC hu -[e^-1](divfK nze) -expr2; congr (_ * _ - _ + 1).
     rewrite -mulrA -sum_seqIndC1_square // mulr_sumr cfnorm_sum_orthogonal //.
     apply: eq_big_seq => xi Sxi.
     have [nz_xi Nxi1] := (cfnorm_seqInd_neq0 nsHL Sxi, Cnat_seqInd1 Sxi).
-    rewrite (normr_idP _) ?mulr_ge0 ?invr_ge0 ?ler0n ?cfnorm_ge0 ?Cnat_ge0 //.
+    rewrite (normr_idP _) ?mulr_ge0 ?invr_ge0 ?ler0n ?cfnorm_ge0 ?natr_ge0 //.
     by rewrite mulrCA !exprMn ['[xi]]lock !mulrA divfK // -lock.
   apply/andP; rewrite -(subr_ge0 w) addrK andbC -subr_ge0 addrC opprB subrK.
   rewrite pmulr_rge0 ?gt0CG // andbb -mulr_natr (mulrAC v).
@@ -478,8 +475,8 @@ split=> // [ | chi /irrP[t def_chi] o_chiSnu].
   have{h1ge0} u_ge0: 0 <= u by rewrite -Lu pmulr_rge0 in h1ge0.
   have [a_le0 | ] := boolP (a <= 0).
     by rewrite -mulrN -sqrrN addr_ge0 ?(u_ge0, mulr_ge0) ?oppr_ge0 ?ler0n.
-  rewrite -real_ltNge ?Creal_Cint // lt_def => /andP[].
-  move/(norm_Cint_ge1 Za)=> a_ge1 a_ge0; rewrite mulrA -mulrBl.
+  rewrite -real_ltNge ?Rreal_int // lt_def => /andP[].
+  move/(norm_intr_ge1 Za)=> a_ge1 a_ge0; rewrite mulrA -mulrBl.
   rewrite (normr_idP _) // -(@mulVf _ 2%:R) ?pnatr_eq0 // in a_ge1.
   rewrite mulr_ge0 // subr_ge0 (le_trans _ (ler_wpM2l u_ge0 a_ge1)) // mulrA.
   by rewrite ler_wpM2r ?ler0n // -(ler_pM2l L_gt0) mulrA Lu -eh mulfK.
@@ -490,13 +487,13 @@ have def_chi0: {in A, chi^\rho =1 (fun _ => '[beta, chi])}.
   move=> x Ax; have [_ Hx] := setD1P Ax.
   have [c _ -> // _] := invDade_seqInd_sum chi defT1.
   rewrite big_cons big1_seq ?addr0 /c => [|xi /S1P[neq_xi /= Sxi]]; last first.
-    rewrite zeta1 -nu_tau ?defZS ?S_Se // raddfB cfdotBl raddfZ_Cnat ?NatS1e //.
+    rewrite zeta1 -nu_tau ?defZS ?S_Se // raddfB cfdotBl raddfZ_nat ?NatS1e //.
     by rewrite cfdotZl !(orthoPr o_chiSnu) ?map_f // mulr0 subr0 conjC0 !mul0r.
-  rewrite Ind1H1 zeta1 divff // scale1r -/beta aut_Cint ?Cint_cfdot_vchar //.
+  rewrite Ind1H1 zeta1 divff // scale1r -/beta aut_intr ?Cint_cfdot_vchar //.
   by rewrite cfnorm_Ind_cfun1 ?cfInd_cfun1 // cfunE cfuniE // Hx mulr1 divfK.
 split=> //; rewrite -mulrA mulrCA cfnormE_invDade; congr (_ * _).
 rewrite mulr_natl -sumr_const; apply: eq_bigr => _ /def_chi0->.
-by rewrite Cint_normK ?Cint_cfdot_vchar.
+by rewrite intr_normK ?Cint_cfdot_vchar.
 Qed.
 
 End Dade_seqIndC1.
@@ -517,13 +514,13 @@ rewrite addrC -irr0 (bigID [pred i | conjC_Iirr i < i]%N) /=.
 set a1 := \sum_(i | _) _; set a2 := \sum_(i | _) _; suffices ->: a1 = a2.
   rewrite -mulr2n -[_ *+ 2]mulr_natr (rpredDl _ (dvdC_mull _ _)) //; last first.
     by rewrite rpred_sum // => i; rewrite rpredM ?Cint_cfdot_vchar_irr.
-  have /CintP[m1 ->] := Cint_cfdot_vchar_irr 0 Zphi.
-  have /CintP[m2 ->] := Cint_cfdot_vchar_irr 0 Zpsi.
+  have /intrP[m1 ->] := Cint_cfdot_vchar_irr 0 Zphi.
+  have /intrP[m2 ->] := Cint_cfdot_vchar_irr 0 Zpsi.
   rewrite [m1]intEsign [m2]intEsign !rmorphMsign mulrACA -!mulrA !rpredMsign.
   by rewrite -natrM !(dvdC_nat 2) Euclid_dvdM.
 rewrite /a2 (reindex_inj (inv_inj (@conjC_IirrK _ _))) /=.
 apply: eq_big => [t | t _]; last first.
-  by rewrite !conjC_IirrE !cfdot_real_conjC ?aut_Cint ?Cint_cfdot_vchar_irr.
+  by rewrite !conjC_IirrE !cfdot_real_conjC ?aut_intr ?Cint_cfdot_vchar_irr.
 rewrite (inv_eq (@conjC_IirrK _ _)) conjC_IirrK -leqNgt ltn_neqAle val_eqE.
 rewrite -!(inj_eq irr_inj) !conjC_IirrE irr0 cfConjC_cfun1 odd_eq_conj_irr1 //.
 by rewrite andbA andbb.
@@ -752,8 +749,8 @@ suffices{min_rho1} sumB_max: sumB <= (e - 1) / (h + 2%:R).
       by rewrite class_supportEr => /bigcupP[x _]; rewrite conjD1g !inE eqxx.
     rewrite -[1]addr0 lerD ?sumr_ge0 // => [|x _]; last first.
       by rewrite -normrX normr_ge0.
-    have Zchit1: 'chi_t 1%g \in Cint by rewrite CintE Cnat_irr1.
-    by rewrite expr_ge1 ?normr_ge0 // norm_Cint_ge1 ?irr1_neq0.
+    have Zchit1: 'chi_t 1%g \in Num.int by rewrite intrE Cnat_irr1.
+    by rewrite expr_ge1 ?normr_ge0 // norm_intr_ge1 ?irr1_neq0.
   pose ea i : algC := #|(H i)^#|%:R / #|L i|%:R.
   apply: (le_trans (y := \sum_i ('[rho i 'chi_t] - ea i))); last first.
     rewrite -subr_ge0 -opprB oppr_ge0 -mulNr opprB addrC mulrC.
@@ -771,7 +768,7 @@ suffices{min_rho1} sumB_max: sumB <= (e - 1) / (h + 2%:R).
     apply/orthoPr=> _ /mapP[xi Sxi ->]; rewrite -['chi_t](signrZK eps).
     by rewrite -def_chi1 cfdotZr o_nu ?mulr0 ?Sr.
   rewrite -[ea i]mulr1 /ea ler_wpM2l ?mulr_ge0 ?invr_ge0 ?ler0n //.
-  by rewrite -/(tau i) -/(beta i) sqr_Cint_ge1 ?Cint_cfdot_vchar_irr.
+  by rewrite -/(tau i) -/(beta i) sqr_intr_ge1 ?Cint_cfdot_vchar_irr.
 rewrite -(mulfK nzh2 sumB) -{2 3}natrD ler_wpM2r ?invr_ge0 ?ler0n //.
 apply: le_trans maxGamma; rewrite mulr_suml.
 pose phi i : 'CF(G) := \sum_(xi <- S i) xi 1%g / e_ i / '[xi] *: nu i xi.
@@ -794,8 +791,8 @@ have{betaP def_beta1} /cfnormDd->: '[Gamma1, X] = 0.
   rewrite !(cfdotDl, cfdotNl) cfdotZl o_nu ?o_phi_nu ?Sr 1?eq_sym // mulr0.
   have[[/orthoPr oSnui_1 _ _] _ _] := betaP i; rewrite -/(S i) in oSnui_1.
   rewrite cfdotC oSnui_1 ?map_f // conjC0 !(add0r, oppr0).
-  have Nxie: xi 1%g / e_ i \in Cnat by apply: dvd_index_seqInd1 _ Sxi.
-  rewrite -(conj_Cnat Nxie) // -cfdotZr -raddfZ_Cnat // -!raddfB /=.
+  have Nxie: xi 1%g / e_ i \in Num.nat by apply: dvd_index_seqInd1 _ Sxi.
+  rewrite -(conj_natr Nxie) // -cfdotZr -raddfZ_nat // -!raddfB /=.
   have [_ Dnu] := cohS i.
   rewrite Dnu ?zcharD1_seqInd ?seqInd_sub_lin_vchar ?Sr ?r1 //.
   by rewrite disjoint_Dade_ortho ?disjoint_Atau 1?eq_sym.
@@ -812,7 +809,7 @@ rewrite big1 ?addr0 => [|j /andP[_ ne_j]]; last by rewrite cfdotZl o_phi ?mulr0.
 rewrite cfdotZl invfM 2!mulrA -n_phi -[_ * _]mulrA mulrC.
 rewrite ler_wpM2r ?cfnorm_ge0 // (le_trans (y := 1)) //.
   by rewrite -{2}(mulVf (nzh i)) ler_wpM2l ?invr_ge0 ?ler0n ?min_i1.
-rewrite mulrC -normCK expr_ge1 ?normr_ge0 // norm_Cint_ge1 //.
+rewrite mulrC -normCK expr_ge1 ?normr_ge0 // norm_intr_ge1 //.
   rewrite Cint_cfdot_vchar ?Znu ?seqInd_zcharW ?Sr //.
 suffices []: c i i1 != 0 \/ c i1 i != 0 by rewrite ?ci1_0.
 apply/Dade_sub_lin_nonorthogonal; rewrite ?mem_irr ?Sr ?r1 //; try exact: cohS.

--- a/theories/PFsection8.v
+++ b/theories/PFsection8.v
@@ -1,28 +1,18 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq path div choice.
-From mathcomp
-Require Import fintype tuple finfun bigop prime ssralg poly finset center.
-From mathcomp
-Require Import fingroup morphism perm automorphism quotient action finalg zmodp.
-From mathcomp
-Require Import gfunctor gproduct cyclic commutator nilpotent pgroup.
-From mathcomp
-Require Import sylow hall abelian maximal frobenius.
-From mathcomp
-Require Import matrix mxalgebra mxrepresentation vector.
-From odd_order
-Require Import BGsection1 BGsection3 BGsection7 BGsection10.
-From odd_order
-Require Import BGsection14 BGsection15 BGsection16.
-From mathcomp
-Require ssrnum.
-From mathcomp
-Require Import algC classfun character inertia vcharacter.
-From odd_order
-Require Import PFsection1 PFsection2 PFsection3 PFsection4 PFsection5.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div choice fintype tuple finfun bigop prime finset.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import ssralg finalg zmodp poly matrix mxalgebra vector.
+From mathcomp Require ssrnum.
+From mathcomp Require Import cyclic center gfunctor commutator pgroup nilpotent.
+From mathcomp Require Import sylow abelian maximal hall frobenius algC.
+From mathcomp Require Import mxrepresentation classfun character inertia.
+From mathcomp Require Import vcharacter.
+From odd_order Require Import BGsection1 BGsection3 BGsection7 BGsection10.
+From odd_order Require Import BGsection14 BGsection15 BGsection16 PFsection1.
+From odd_order Require Import PFsection2 PFsection3 PFsection4 PFsection5.
 
 (******************************************************************************)
 (* This file covers Peterfalvi, Section 8: Structure of a Minimal Simple      *)

--- a/theories/PFsection9.v
+++ b/theories/PFsection9.v
@@ -1,27 +1,21 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq path div choice fintype.
-From mathcomp
-Require Import tuple finfun bigop order prime binomial ssralg poly finset.
-From mathcomp
-Require Import fingroup morphism perm automorphism quotient action finalg zmodp.
-From mathcomp
-Require Import gfunctor gproduct cyclic commutator center gseries nilpotent.
-From mathcomp
-Require Import pgroup sylow hall abelian maximal frobenius.
-From mathcomp
-Require Import matrix mxalgebra mxrepresentation mxabelem vector.
-From odd_order
-Require Import BGsection1 BGsection3 BGsection7 BGsection15 BGsection16.
-From mathcomp
-Require Import algC classfun character inertia vcharacter.
-From odd_order
-Require Import PFsection1 PFsection2 PFsection3 PFsection4.
-From odd_order
-Require Import PFsection5 PFsection6 PFsection8.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div choice fintype tuple finfun bigop prime finset.
+From mathcomp Require Import binomial order.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct.
+From mathcomp Require Import ssralg finalg zmodp poly ssrnum archimedean matrix.
+From mathcomp Require Import mxalgebra vector.
+From mathcomp Require Import cyclic center gfunctor commutator gseries pgroup.
+From mathcomp Require Import nilpotent sylow abelian maximal hall frobenius.
+From mathcomp Require Import algC.
+From mathcomp Require Import mxrepresentation mxabelem classfun character.
+From mathcomp Require Import inertia vcharacter.
+From odd_order Require Import BGsection1 BGsection3 BGsection7 BGsection15.
+From odd_order Require Import BGsection16 PFsection1 PFsection2 PFsection3.
+From odd_order Require Import PFsection4 PFsection5 PFsection6 PFsection8.
 
 (******************************************************************************)
 (* This file covers Peterfalvi, Section 9: On the maximal subgroups of Types  *)
@@ -841,6 +835,8 @@ rewrite sz_mu size_filter nb_redM //= norm_joinEr ?(subset_trans sCM) //.
 by rewrite -group_modl //= setIC [C]unlock setIA tiHU setI1g mulg1.
 Qed.
 
+Import Num.Theory.
+
 Let isIndHC (zeta : 'CF(M)) :=
   [/\ zeta 1%g = (q * u)%:R, zeta \in S_ H0C
     & exists2 xi : 'CF(HC), xi \is a linear_char & zeta = 'Ind xi].
@@ -900,7 +896,7 @@ have Part_a: part_a.
     have [_ defInd_t _ imInd_t _] := cfInd_sum_Inertia t nsHHU.
     have /imsetP[r tTr ->]: s \in Ind_Iirr HU @: irr_constt ('Ind[T] 'chi_t).
       by rewrite imInd_t constt_Ind_Res.
-    by rewrite defInd_t ?cfInd1 // dvdC_mulr ?dvdC_nat // Cint_Cnat ?Cnat_irr1.
+    by rewrite defInd_t ?cfInd1 // dvdC_mulr ?dvdC_nat // intr_nat ?Cnat_irr1.
   have /exists_inP[w W1w nt_t_w]: [exists w in W1bar, 'Res[H1 :^ w] theta != 1].
     rewrite -negb_forall_in; apply: contra t_neq0 => /forall_inP=> tH1w1.
     rewrite -irr_eq1 -(cfQuoK nsH0H kertH0) -/theta -Dtheta.
@@ -1257,8 +1253,6 @@ rewrite (subsetP sXthetaXH0U') // !andbT inertia_Ind_irr ?gFnormal //.
 by apply/subsetP=> y /setIP[My /inertiaJ/esym/injXtheta->].
 Qed.
 
-Import ssrnum Num.Theory.
-
 (* This is Peterfalvi (9.9); we have exported the fact that HU / H0 is a      *)
 (* Frobenius group in case (c), as this is directly used in (9.10).           *)
 Lemma typeP_Galois_characters (is_Galois : typeP_Galois) :
@@ -1360,7 +1354,7 @@ have Part_a': part_a'.
   rewrite -quotientSK ?gFsub_trans ?quotient_der //= -/C.
   by rewrite -(der_dprod 1 defHCbar) (derG1P abHbar) dprod1g.
 split=> // [s /Part_a[r ->] | | {Part_a' part_a'}red_H0C'].
-- by rewrite Du cfInd1 // dvdC_mulr // Cint_Cnat ?Cnat_irr1.
+- by rewrite Du cfInd1 // dvdC_mulr // intr_nat ?Cnat_irr1.
 - split=> // mu_j /H0C_mu H0C_mu_j; have [s XH0Cs Dmuj] := seqIndP H0C_mu_j.
   have [|s1u [xi lin_xi Ds]] := Part_a' s.
     by rewrite (subsetP _ _ XH0Cs) ?Iirr_kerDS // genS ?setUS ?der_sub.
@@ -1551,7 +1545,7 @@ have sS10: cfConjC_subset S1 (S_ H0C').
   split=> [||chi]; first by rewrite filter_uniq.
     by apply: mem_subseq; apply: filter_subseq.
   rewrite !mem_filter !inE cfunE /= => /andP[/eqP <- S0chi].
-  by rewrite cfAut_seqInd // andbT conj_Cnat ?(Cnat_seqInd1 S0chi).
+  by rewrite cfAut_seqInd // andbT conj_natr ?(Cnat_seqInd1 S0chi).
 have cohS1: coherent S1 M^# tau.
   apply: uniform_degree_coherence (subset_subcoherent scohS0 sS10) _.
   by apply: all_pred1_constant (q * a)%:R _ _; rewrite all_map filter_all.
@@ -1656,7 +1650,7 @@ without loss [[eqS12 irrS1 H0C_S1] [Da_p defC] [S3qu ne_qa_qu] [oS1 oS1ua]]:
     apply: leif_sum => i _; apply/leifP; rewrite lt0r !mulf_eq0 invr_eq0.
     set psi := tnth _ i; have Spsi := sS20 psi (mem_tnth _ _).
     rewrite !negb_or (seqInd1_neq0 _ Spsi) //= (cfnorm_seqInd_neq0 _ Spsi) //=.
-    by rewrite divr_ge0 ?exprn_ge0 ?cfnorm_ge0 ?Cnat_ge0 ?(Cnat_seqInd1 Spsi).
+    by rewrite divr_ge0 ?exprn_ge0 ?cfnorm_ge0 ?natr_ge0 ?(Cnat_seqInd1 Spsi).
   have [lb0S2 | ] := boolP (lb0 < sumnS S2).
     exists chi => //; have /hasP[xi S1xi _]: has predT S1 by rewrite has_predT.
     have xi1: xi 1%g = (q * a)%:R.
@@ -2024,9 +2018,10 @@ have o_alpha_S3: orthogonal alpha^\tau (map tau3 S3).
   rewrite /orthogonal /= andbT all_map.
   apply: contraFT (lt_geF gtS4alpha) => /allPn[lam0 S3lam0 /= alpha_lam0].
   set ca := '[_, _] in alpha_lam0; pose al0 := (-1) ^+ (ca < 0)%R *: alpha.
-  have{alpha_lam0} al0_lam0: '[al0^\tau, tau3 lam0] > 0.
-    have Zca: ca \in Cint by rewrite Cint_cfdot_vchar ?Ztau // Ztau3 ?mem_zchar.
-    by rewrite linearZ cfdotZl (canLR (signrMK _) (CintEsign Zca)) normr_gt0.
+  have Zca: ca \in Num.int.
+    by rewrite Cint_cfdot_vchar ?Ztau // Ztau3 ?mem_zchar.
+  have{alpha_lam0 Zca} al0_lam0: '[al0^\tau, tau3 lam0] > 0.
+    by rewrite linearZ cfdotZl (canLR (signrMK _) (intrEsign Zca)) normr_gt0.
   rewrite -Itau // -(cfnorm_sign (ca < 0)%R) -linearZ /= -/al0.
   have S4_dIirrK: {in map tau3 S4, cancel (dirr_dIirr id) (@dchi _ _)}.
     apply: dirr_dIirrPE => _ /mapP[lam S4lam ->].
@@ -2042,7 +2037,7 @@ have o_alpha_S3: orthogonal alpha^\tau (map tau3 S3).
   apply: le_trans (_ : #|dirr_constt al0^\tau|%:R <= _); last first.
     have Zal0: al0^\tau \in 'Z[irr G] by rewrite Ztau ?rpredZsign.
     rewrite cnorm_dconstt // -sumr_const ler_sum // => i al0_i.
-    by rewrite sqr_Cint_ge1 ?gt_eqF -?dirr_consttE // Cint_Cnat ?Cnat_dirr.
+    by rewrite sqr_intr_ge1 ?gt_eqF -?dirr_consttE // intr_nat ?Cnat_dirr.
   rewrite leC_nat subset_leq_card //; apply/subsetP=> _ /mapP[nu S4nu ->].
   rewrite dirr_consttE S4_dIirrK //; congr (_ > 0): al0_lam0.
   rewrite {al0}linearZ !cfdotZl /=; congr (_ * _) => {ca}; apply/eqP.
@@ -2098,7 +2093,7 @@ have [Gamma [S4_Gamma normGamma [b Dbeta]]]:
   have [Itau34 Ztau34] := sub_iso_to sZS43 sub_refl IZtau3.
   have Z_G: G \in 'Z[map tau3 S4].
     have [_ -> ->] := orthonormal_span (map_orthonormal Itau34 o1S4) S4G.
-    rewrite big_seq rpred_sum // => xi S4xi; rewrite rpredZ_Cint ?mem_zchar //.
+    rewrite big_seq rpred_sum // => xi S4xi; rewrite rpredZ_int ?mem_zchar //.
     rewrite -(addrK G' G) -Dbeta cfdotBl (orthoPl oG'4) // subr0.
     rewrite Cint_cfdot_vchar ?Ztau //.
     by have{xi S4xi} [xi S4xi ->] := mapP S4xi; rewrite Ztau34 ?mem_zchar.
@@ -2111,7 +2106,7 @@ have [Gamma [S4_Gamma normGamma [b Dbeta]]]:
     move=> psi S1psi; rewrite Dbeta dG' !cfdotDl (orthoPl oD1) ?map_f // addr0.
     rewrite cfdotC (span_orthogonal oS14tau) ?rmorph0 ?add0r //.
     by rewrite memv_span ?map_f.
-  have Zb: b \in Cint.
+  have Zb: b \in Num.int.
     rewrite rpredD ?rpred_nat // -betaS1_B // Cint_cfdot_vchar ?Ztau //.
     by rewrite Ztau1 ?mem_zchar.
   have{} dB: B = - (u %/ a)%:R *: tau1 psi1 + b *: \sum_(psi <- S1) tau1 psi.
@@ -2129,10 +2124,10 @@ have [Gamma [S4_Gamma normGamma [b Dbeta]]]:
     by rewrite add0r n1psi1 oSS // subr0 mulr1 rmorphN conjCK subrr scale0r.
   have Gge1: 1 <= '[G] ?= iff ('[G] == 1).
     rewrite eq_sym; apply: leif_eq.
-    have N_G: '[G] \in Cnat.
+    have N_G: '[G] \in Num.nat.
       apply: Cnat_cfnorm_vchar; apply: zchar_sub_irr Z_G => _ /mapP[nu S4nu ->].
       by rewrite Ztau34 ?mem_zchar.
-    rewrite -(truncCK N_G) ler1n lt0n -eqC_nat truncCK {N_G}// cfnorm_eq0.
+    rewrite -(truncK N_G) ler1n lt0n -eqC_nat truncK {N_G}// cfnorm_eq0.
     have: '[beta^\tau, (lam1 - lam1^*%CF)^\tau] != 0.
       rewrite Itau // cfdotBl cfdotZl !cfdotBr n1lam1.
       rewrite (seqInd_conjC_ortho _ _ _ Slam1) ?mFT_odd // subr0.
@@ -2150,9 +2145,9 @@ have [Gamma [S4_Gamma normGamma [b Dbeta]]]:
       congr (_ + _); rewrite !addrA dG' cfnormDd; last first.
         by rewrite cfdotC (span_orthogonal oD1) ?rmorph0 // memv_span ?inE.
       congr (_ + _); rewrite dB scaleNr [- _ + _]addrC cfnormB !cfnormZ.
-      rewrite normr_nat Cint_normK // scaler_sumr cfdotZr rmorph_nat.
+      rewrite normr_nat intr_normK // scaler_sumr cfdotZr rmorph_nat.
       rewrite cfnorm_map_orthonormal // cfproj_sum_orthonormal //.
-      rewrite Itau1 ?mem_zchar// n1psi1 mulr1 rmorphM/= rmorph_nat conj_Cint //.
+      rewrite Itau1 ?mem_zchar// n1psi1 mulr1 rmorphM/= rmorph_nat conj_intr //.
       rewrite -mulr2n oS1ua -muln_divA // mul2n -addrA addrCA -natrX mulrBl.
       by congr (_ + (_ - _)); rewrite -mulrnAl -mulrnA muln2 mulrC.
     rewrite Itau // cfnormBd; last first.
@@ -2168,8 +2163,8 @@ have [Gamma [S4_Gamma normGamma [b Dbeta]]]:
     rewrite /= -(subr_eq0 b 1) -mulf_eq0 mulrBr mulr1 eq_sym.
     apply: leif_eq; rewrite subr_ge0.
     have [-> | nz_b] := eqVneq b 0; first by rewrite expr2 mul0r.
-    rewrite (le_trans (real_ler_norm _)) ?Creal_Cint // -[`|b|]mulr1.
-    by rewrite -Cint_normK // ler_pM2l ?normr_gt0 // norm_Cint_ge1.
+    rewrite (le_trans (real_ler_norm _)) ?Rreal_int // -[`|b|]mulr1.
+    by rewrite -intr_normK // ler_pM2l ?normr_gt0 // norm_intr_ge1.
   have [_ /esym] := leif_trans Gge1 (leif_trans ubDelta ubDeltaG).
   rewrite eqxx => /and3P[/eqP normG1 /eqP Delta0 /pred2P b01].
   exists G; split=> //; exists (b != 0).
@@ -2183,7 +2178,7 @@ have [X S1X [Delta [Dalpha _ oD1]]]:= orthogonal_split (map tau1 S1) alpha^\tau.
 pose x := 1 + '[X, tau1 psi1].
 have alphaS1_X: {in S1, forall psi, '[alpha^\tau, tau1 psi] = '[X, tau1 psi]}.
   by move=> psi S1psi; rewrite Dalpha cfdotDl (orthoPl oD1) ?map_f // addr0.
-have Zx: x \in Cint.
+have Zx: x \in Num.int.
   rewrite rpredD ?rpred1 // -alphaS1_X // Cint_cfdot_vchar ?Ztau //.
   by rewrite Ztau1 ?mem_zchar.
 have{alphaS1_X S1X} defX: X = x *: (\sum_(psi <- S1) tau1 psi) - tau1 psi1.

--- a/theories/stripped_odd_order_theorem.v
+++ b/theories/stripped_odd_order_theorem.v
@@ -1,13 +1,10 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require structures.
-Require mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require ssrbool ssrfun eqtype ssrnat fintype finset fingroup.
-From mathcomp
-Require morphism quotient action gfunctor gproduct commutator gseries nilpotent.
-From odd_order
-Require PFsection14.
+From mathcomp Require ssreflect ssrfun ssrbool eqtype ssrnat fintype finset.
+From mathcomp Require fingroup morphism quotient action gproduct.
+From mathcomp Require gfunctor commutator gseries nilpotent.
+From odd_order Require PFsection14.
 
 (******************************************************************************)
 (* This file contains a minimal, self-contained reformulation of the Odd      *)

--- a/theories/wielandt_fixpoint.v
+++ b/theories/wielandt_fixpoint.v
@@ -1,21 +1,15 @@
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 From HB Require Import structures.
-Require Import mathcomp.ssreflect.ssreflect.
-From mathcomp
-Require Import ssrbool ssrfun eqtype ssrnat seq path div.
-From mathcomp
-Require Import fintype bigop prime binomial finset ssralg fingroup finalg.
-From mathcomp
-Require Import morphism perm automorphism quotient action gfunctor commutator.
-From mathcomp
-Require Import gproduct zmodp cyclic center pgroup gseries nilpotent sylow.
-From mathcomp
-Require Import finalg finmodule abelian frobenius maximal extremal hall.
-From mathcomp
-Require Import matrix mxalgebra mxrepresentation mxabelem.
-From odd_order
-Require Import BGsection1.
+From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
+From mathcomp Require Import div fintype bigop prime finset binomial.
+From mathcomp Require Import fingroup morphism perm automorphism quotient.
+From mathcomp Require Import action gproduct ssralg finalg zmodp matrix.
+From mathcomp Require Import mxalgebra.
+From mathcomp Require Import cyclic center gfunctor commutator finmodule.
+From mathcomp Require Import gseries pgroup nilpotent sylow abelian maximal.
+From mathcomp Require Import hall frobenius extremal mxrepresentation mxabelem.
+From odd_order Require Import BGsection1.
 
 (******************************************************************************)
 (*   This file provides the proof of the Wielandt fixpoint order formula,     *)


### PR DESCRIPTION
This PR is intended to be compatible with math-comp/math-comp#1237 (not tested yet).

The import lists are now in the dependency order, except for some stuff imported in the middle of a file.