### PR TITLE
Address the deprecation warnings introduced in MathComp <= 2.4

### DIFF
--- a/theories/BGappendixAB.v
+++ b/theories/BGappendixAB.v
@@ -28,7 +28,8 @@ Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
 Local Open Scope ring_scope.
-Import GroupScope GRing.Theory.
+Local Open Scope group_scope.
+Import GRing.Theory.
 
 Section AppendixA.
 
@@ -193,7 +194,7 @@ move: (kquo_repr _) (kquo_mx_faithful rAG) => /=; set K := rker _.
 rewrite def_dA => r2G; move/der1_odd_GL2_charf; move/implyP.
 rewrite quotient_odd //= -/G; apply: etrans; apply: eq_pgroup => p'.
 have [p_pr _ _] := pgroup_pdiv pE ntE.
-by rewrite (fmorph_char (gen _ _)) (charf_eq (char_Fp _)).
+by rewrite (fmorph_pchar (gen _ _)) (pcharf_eq (pchar_Fp _)).
 Qed.
 
 Section A5.

--- a/theories/BGappendixC.v
+++ b/theories/BGappendixC.v
@@ -18,7 +18,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope Order.TTheory GRing.Theory FinRing.Theory Num.Theory.
+Import Order.TTheory GRing.Theory FinRing.Theory Num.Theory.
+Local Open Scope group_scope.
 Local Open Scope ring_scope.
 
 Section AppendixC.
@@ -48,8 +49,8 @@ Section ExpandHypotheses.
 Hypothesis ltqp : (q < p)%N.
 
 (* From the fieldH assumption. *)
-Variables (fT : finFieldType) (charFp : p \in [char fT]).
-Local Notation F := (PrimeCharType charFp).
+Variables (fT : finFieldType) (charFp : p \in [pchar fT]).
+Local Notation F := (pPrimeCharType charFp).
 Local Notation galF := [the splittingFieldType 'F_p of F].
 Let Fpq : {vspace F} := fullv.
 Let Fp : {vspace F} := 1%VS.
@@ -58,10 +59,10 @@ Hypothesis oF : #|F| = (p ^ q)%N.
 Let oF_p : #|'F_p| = p. Proof. exact: card_Fp. Qed.
 Let oFp : #|Fp| = p.
 Proof.
-by rewrite (@card_vspace1 _ _ (Falgebra.class (PrimeCharType _))).
+by rewrite (@card_vspace1 _ _ (Falgebra.class (pPrimeCharType _))).
 Qed.
 Let oFpq : #|Fpq| = (p ^ q)%N. Proof. by rewrite card_vspacef. Qed.
-Let dimFpq : \dim Fpq = q. Proof. by rewrite primeChar_dimf oF pfactorK. Qed.
+Let dimFpq : \dim Fpq = q. Proof. by rewrite pprimeChar_dimf oF pfactorK. Qed.
 
 Variables (sigma : {morphism P >-> F}) (sigmaU : {morphism U >-> {unit F}}).
 Hypotheses (inj_sigma : 'injm sigma) (inj_sigmaU : 'injm sigmaU).
@@ -208,7 +209,7 @@ Qed.
 Let frobH : [Frobenius H = P ><| U].
 Proof.
 apply/Frobenius_semiregularP=> // [||u /setD1P[ntu Uu]].
-- by rewrite -(morphim_injm_eq1 inj_sigma) // im_sigma finRing_nontrivial.
+- by rewrite -(morphim_injm_eq1 inj_sigma) // im_sigma finNzRing_nontrivial.
 - rewrite -cardG_gt1 oU ltn_divRL ?dvdn_pred_predX // mul1n -!subn1.
   by rewrite ltn_sub2r ?(ltn_exp2l 0) ?(ltn_exp2l 1) ?prime_gt1.
 apply/trivgP/subsetP=> x /setIP[Px /cent1P/commgP].
@@ -279,7 +280,7 @@ have sizePa: size Pa = q.+1.
   rewrite sum_nat_const muln2 -addnn -addSn addnK.
   by rewrite -galois_dim ?finField_galois ?subvf // dimv1 divn1 dimFpq.
 have sizePa1: size (Pa - 1) = q.+1.
-  by rewrite size_addl // size_opp size_poly1 sizePa.
+  by rewrite size_polyDl // size_polyN size_poly1 sizePa.
 have nz_Pa1 : Pa - 1 != 0 by rewrite -size_poly_eq0 sizePa1.
 by rewrite -ltnS -oFp -sizePa1 cardE max_poly_roots ?enum_uniq.
 Qed.
@@ -350,7 +351,7 @@ have [q_gt4 | q_le4] := ltnP 4 q.
     (0 < m < 5)%N -> \sum_(i in predC linH) `|'chi_i s_m| ^+ 2 <= #|P|%:R.
   - case/andP=> m_gt0 m_lt5; have{m_gt0 m_lt5} P1sm: s_m \in P^#.
       rewrite !inE groupX // -order_dvdn -(order_injm inj_sigma) // sigmaE.
-      by rewrite andbT order_primeChar ?oner_neq0 ?gtnNdvd ?(leq_trans m_lt5).
+      by rewrite andbT order_pprimeChar ?oner_neq0 ?gtnNdvd ?(leq_trans m_lt5).
     have ->: #|P| = (#|P| * (s_m \in s_m ^: H))%N by rewrite class_refl ?muln1.
     have{P1sm} /eqP <-: 'C_H[s ^+ m] == P.
       rewrite eqEsubset (Frobenius_cent1_ker frobH) // subsetI normal_sub //=.
@@ -407,7 +408,7 @@ have /existsP[c nz_fc]: [exists c, ~~ [exists d, root (f c) d]].
 have{nz_fc} /= nz_fc: ~~ root (f c) _ by apply/forallP; rewrite -negb_exists.
 have sz_fc_lhs: size ('X * ('X - 2%:P) * ('X - c%:P)) = 4%N.
   by rewrite !(size_mul, =^~ size_poly_eq0) ?size_polyX ?size_XsubC.
-have sz_fc: size (f c) = 4%N by rewrite size_addl ?size_XsubC sz_fc_lhs.
+have sz_fc: size (f c) = 4%N by rewrite size_polyDl ?size_XsubC sz_fc_lhs.
 have irr_fc: irreducible_poly (f c) by apply: cubic_irreducible; rewrite ?sz_fc.
 have fc_monic : f c \is monic.
   rewrite monicE lead_coefDl ?size_XsubC ?sz_fc_lhs // -monicE.
@@ -460,7 +461,7 @@ Qed.
 
 Section AppendixC3.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Variables y : gT.
 Hypotheses (QP0y : y \in [~: Q, P0]) (nUP0y : P0 :^ y \subset 'N(U)).
@@ -609,7 +610,7 @@ have sUsXp m a j n u s1 v:
   rewrite conjXg -!(mulgA _ (s ^+ k)) ![s ^+ k * _]conjgC [RHS]mulgA.
   rewrite (mulgA (u ^+ p)) -expUMp //.
   rewrite {}Duv ![s ^+ m * _]conjgC !conjXg -![_ * _ * s ^- n]mulgA.
-  move/mulgI/(congr1 (Frobenius_aut charFp \o sigma))=> /= Duv_p.
+  move/mulgI/(congr1 (pFrobenius_aut charFp \o sigma))=> /= Duv_p.
   congr (_ * _); apply/(injmP inj_sigma); rewrite ?in_PU //.
   by rewrite !{1}sigmaE ?in_PU // rmorphB !rmorphMn rmorph1 in Duv_p *.
 have odd_P: odd #|P| by rewrite oP oddX odd_p orbT.
@@ -668,7 +669,7 @@ have{sUsXp} Ds2p: s2def (w1 ^+ p) (w2 ^+ p) (w3 ^+ p).
   rewrite expUMp ?groupV // !expgVn in usv1pP usv2pP.
   rewrite !(=^~ conjXg _ _ p, expUMp) ?groupV -1?[t]expg1 ?nUtn ?nUtVn //.
   apply: Ds2 usv1pP usv2pP usv3pP => //.
-  by rewrite !psiX // -!Frobenius_autE -rmorphD Dab rmorph_nat.
+  by rewrite !psiX // -!pFrobenius_autE -rmorphD Dab rmorph_nat.
 have{} Ds2: s2def w1 w2 w3 by apply: Ds2 usv1P usv2P usv3P.
 wlog [Uw1 Uw2 Uw3]: w1 w2 w3 Ds2p Ds2 / [/\ w1 \in U, w2 \in U & w3 \in U].
   by move/(_ w1 w2 w3)->; rewrite ?(nUtVn, nUtVn 1%N, nUtn 1%N, in_group).
@@ -765,7 +766,7 @@ apply: wlog_neg; rewrite -ltnNge => ltqp.
 have [F sigma /isomP[inj_sigma im_sigma] defP0] := fieldH.
 case=> sigmaU inj_sigmaU sigmaJ.
 have oF: #|F| = (p ^ q)%N by rewrite -cardsT -im_sigma card_injm.
-have charFp: p \in [char F] := card_finCharP oF pr_p.
+have charFp: p \in [pchar F] := card_finPcharP oF pr_p.
 have sP0P: P0 \subset P by rewrite -defP0 subsetIl.
 pose s := invm inj_sigma 1%R.
 have sigma_s: sigma s = 1%R by rewrite invmK ?im_sigma ?inE.

--- a/theories/BGsection1.v
+++ b/theories/BGsection1.v
@@ -56,7 +56,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section Definitions.
 
@@ -95,12 +95,11 @@ Definition p_norm_abelian p (D : {set gT}) : pred {group gT} :=
 Definition Puig_succ (D E : {set gT}) :=
   <<\bigcup_(A in subgroups D | norm_abelian E A) A>>.
 
-Definition Puig_rec D := iter n (Puig_succ D) 1.
+Definition Puig_at D := iter n (Puig_succ D) 1.
 
 End Definitions.
 
-(* This must be defined outside a Section to avoid spurrious delta-reduction *)
-Definition Puig_at := nosimpl Puig_rec.
+Arguments Puig_at : simpl never.
 
 Definition Puig_inf (gT : finGroupType) (G : {set gT}) := Puig_at #|G|.*2 G.
 
@@ -1259,7 +1258,7 @@ Implicit Types (D E : {set gT}) (G H : {group gT}).
 
 Lemma Puig0 D : 'L_{0}(D) = 1. Proof. by []. Qed.
 Lemma PuigS n D : 'L_{n.+1}(D) = 'L_[D]('L_{n}(D)). Proof. by []. Qed.
-Lemma Puig_recE n D : Puig_rec n D = 'L_{n}(D). Proof. by []. Qed.
+Lemma Puig_atE n D : Puig_at n D = 'L_{n}(D). Proof. by []. Qed.
 Lemma Puig_def D : 'L(D) = 'L_[D]('L_*(D)). Proof. by []. Qed.
 
 Local Notation "D --> E" := (generated_by (norm_abelian D) E)

--- a/theories/BGsection10.v
+++ b/theories/BGsection10.v
@@ -31,7 +31,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Reserved Notation "\alpha ( M )" (format "\alpha ( M )").
 Reserved Notation "\beta ( M )" (format "\beta ( M )").

--- a/theories/BGsection11.v
+++ b/theories/BGsection11.v
@@ -26,7 +26,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section Section11.
 

--- a/theories/BGsection12.v
+++ b/theories/BGsection12.v
@@ -30,7 +30,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
+
 Section Definitions.
 
 Variables (gT : finGroupType) (M : {set gT}).

--- a/theories/BGsection13.v
+++ b/theories/BGsection13.v
@@ -20,7 +20,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section Section13.
 

--- a/theories/BGsection14.v
+++ b/theories/BGsection14.v
@@ -70,7 +70,8 @@ Unset Printing Implicit Defensive.
 
 Local Open Scope ring_scope.
 Local Open Scope nat_scope.
-Import GRing.Theory Order.TTheory Num.Theory GroupScope.
+Local Open Scope group_scope.
+Import GRing.Theory Order.TTheory Num.Theory.
 
 Section Definitons.
 

--- a/theories/BGsection15.v
+++ b/theories/BGsection15.v
@@ -25,7 +25,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 #[warning="-postfix-notation-not-level-1"]
 Reserved Notation "M `_ \F" (left associativity, format "M `_ \F").

--- a/theories/BGsection16.v
+++ b/theories/BGsection16.v
@@ -84,7 +84,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 #[warning="-postfix-notation-not-level-1"]
 Reserved Notation "M `_ \s" (left associativity, format "M `_ \s").

--- a/theories/BGsection2.v
+++ b/theories/BGsection2.v
@@ -24,7 +24,8 @@ Unset Printing Implicit Defensive.
 
 Section BGsection2.
 
-Import GroupScope GRing.Theory FinRing.Theory poly.UnityRootTheory ssrint.IntDist.
+Import GRing.Theory.
+Local Open Scope group_scope.
 Local Open Scope ring_scope.
 
 Implicit Types (F : fieldType) (gT : finGroupType) (p : nat).
@@ -260,13 +261,13 @@ Proof.
 have splitF: group_splitting_field F (Zp_group h).
   move: prim_eps (abelianS (subsetT (Zp h)) (Zp_abelian _)).
   by rewrite -{1}(card_Zp h_gt0); apply: primitive_root_splitting_abelian.
-have F'Zh: [char F]^'.-group (Zp h).
+have F'Zh: [pchar F]^'.-group (Zp h).
   apply/pgroupP=> p p_pr; rewrite card_Zp // => /dvdnP[d def_h].
   apply/negP=> /= charFp.
   have d_gt0: d > 0 by move: h_gt0; rewrite def_h; case d.
   have: eps ^+ d == 1.
-    rewrite -(inj_eq (fmorph_inj (Frobenius_aut charFp))).
-    by rewrite rmorph1 /= Frobenius_autE -exprM -def_h eps_h.
+    rewrite -(inj_eq (fmorph_inj (pFrobenius_aut charFp))).
+    by rewrite rmorph1 /= pFrobenius_autE -exprM -def_h eps_h.
   by rewrite -(prim_order_dvd prim_eps) gtnNdvd // def_h ltn_Pmulr // prime_gt1.
 case: (ltngtP h 1) => [|h_gt1|h1]; last first; last by rewrite ltnNge h_gt0.
   rewrite /sumV mxdirectE /= h1 !big_ord1; split=> //.
@@ -287,7 +288,7 @@ have lin_rZ m (U : 'M_(m, q)) a:
 rewrite mxdirect_sum_eigenspace => [j k _ _|]; first exact: inj_eps.
 split=> //; apply/eqmxP; rewrite submx1.
 wlog [I M /= simM <- _]: / mxsemisimple rZ 1.
-  exact: mx_reducible_semisimple (mxmodule1 _) (mx_Maschke rZ F'Zh) _.
+  exact: mx_reducible_semisimple (mxmodule1 _) (mx_Maschke_pchar rZ F'Zh) _.
 apply/sumsmx_subP=> i _; have simMi := simM i; have [modMi _ _] := simMi.
 set v := nz_row (M i); have nz_v: v != 0 by apply: nz_row_mxsimple simMi.
 have rankMi: \rank (M i) = 1%N.
@@ -299,7 +300,7 @@ have [a defvg]: exists a, v *m rZ 1%R = a *: v.
   by apply/sub_rVP; rewrite -defMi mxmodule_trans ?socle_module ?defMi.
 have: a ^+ h - 1 == 0.
   apply: contraR nz_v => nz_pZa; rewrite -(eqmx_eq0 (eqmx_scale _ nz_pZa)).
-  by rewrite scalerBl scale1r -lin_rZ // subr_eq0 char_Zp ?mulmx1.
+  by rewrite scalerBl scale1r -lin_rZ // subr_eq0 pchar_Zp ?mulmx1.
 rewrite subr_eq0; move/eqP; case/(prim_rootP prim_eps) => k def_a.
 by rewrite defMi (sumsmx_sup k) // /V_ -def_a; apply/eigenspaceP.
 Qed.
@@ -583,19 +584,19 @@ Theorem repr_extraspecial_prime_sdprod_cycle p n gT (G P H : {group gT}) :
     {in H^#, forall x, 'C_P[x] = 'Z(P)} ->
   (h %| p ^ n + 1) || (h %| p ^ n - 1)
   /\ ((h != p ^ n + 1)%N -> forall F q (rG : mx_representation F G q),
-      [char F]^'.-group G -> mx_faithful rG -> rfix_mx rG H != 0).
+      [pchar F]^'.-group G -> mx_faithful rG -> rfix_mx rG H != 0).
 Proof.
 move=> pP esP sdPH_G cycH h oPpn co_p_h primeHP.
 set dvd_h_pn := _ || _; set neq_h_pn := h != _.
 suffices IH F q (rG : mx_representation F G q):
-    [char F]^'.-group G -> mx_faithful rG ->
+    [pchar F]^'.-group G -> mx_faithful rG ->
   dvd_h_pn && (neq_h_pn ==> (rfix_mx rG H != 0)).
 - split=> [|ne_h F q rG F'G ffulG]; last first.
     by case/andP: (IH F q rG F'G ffulG) => _; rewrite ne_h.
   pose r := pdiv #|G|.+1.
   have r_pr: prime r by rewrite pdiv_prime // ltnS cardG_gt0.
-  have F'G: [char 'F_r]^'.-group G.
-    rewrite /pgroup (eq_pnat _ (eq_negn (charf_eq (char_Fp r_pr)))).
+  have F'G: [pchar 'F_r]^'.-group G.
+    rewrite /pgroup (eq_pnat _ (eq_negn (pcharf_eq (pchar_Fp r_pr)))).
     rewrite p'natE // -prime_coprime // (coprime_dvdl (pdiv_dvd _)) //.
     by rewrite /coprime -addn1 gcdnC gcdnDl gcdn1.
   by case/andP: (IH _ _ _ F'G (regular_mx_faithful _ _)).
@@ -603,7 +604,7 @@ move=> F'G ffulG.
 without loss closF: F rG F'G ffulG / group_closure_field F gT.
   move=> IH; apply: (@group_closure_field_exists gT F) => [[Fs f clFs]].
   rewrite -(map_mx_eq0 f) map_rfix_mx {}IH ?map_mx_faithful //.
-  by rewrite (eq_p'group _ (fmorph_char f)).
+  by rewrite (eq_p'group _ (fmorph_pchar f)).
 have p_pr := extraspecial_prime pP esP; have p_gt1 := prime_gt1 p_pr.
 have oZp := card_center_extraspecial pP esP; have[_ prZ] := esP.
 have{sdPH_G} [nsPG sHG defG nPH tiPH] := sdprod_context sdPH_G.
@@ -617,11 +618,11 @@ have defCP: 'C_G(P) = 'Z(P).
   apply/subsetP=> x; case/setIP; case/setU1P=> [-> // | H'x].
   rewrite -sub_cent1; move/setIidPl; rewrite primeHP // => defP.
   by have:= min_card_extraspecial pP esP; rewrite -defP oZp (leq_exp2l 3 1).
-have F'P: [char F]^'.-group P by apply: pgroupS sPG F'G.
-have F'H: [char F]^'.-group H by apply: pgroupS sHG F'G.
+have F'P: [pchar F]^'.-group P by apply: pgroupS sPG F'G.
+have F'H: [pchar F]^'.-group H by apply: pgroupS sHG F'G.
 wlog{ffulG F'G} [irrG regZ]: q rG / mx_irreducible rG /\ rfix_mx rG 'Z(P) = 0.
   move=> IH; wlog [I W /= simW defV _]: / mxsemisimple rG 1%:M.
-    exact: (mx_reducible_semisimple (mxmodule1 _) (mx_Maschke rG F'G)).
+    exact: (mx_reducible_semisimple (mxmodule1 _) (mx_Maschke_pchar rG F'G)).
   have [z Zz ntz]: exists2 z, z \in 'Z(P) & z != 1%g.
     by apply/trivgPn; rewrite -cardG_gt1 oZp prime_gt1.
   have Gz := subsetP sPG z (subsetP (center_sub P) z Zz).
@@ -653,7 +654,7 @@ wlog [M simM _]: / exists2 M, mxsimple rP M & (M <= 1%:M)%MS.
   by apply: (mxsimple_exists (mxmodule1 _)); last case irrG.
 have{M simM irrG regZ F'P} [irrP def_q]: mx_irreducible rP /\ q = (p ^ n)%N.
   have [modM nzM _]:= simM.
-  have [] := faithful_repr_extraspecial _ _ oPpn _ _ simM => // [|<- isoM].
+  have [|||||<- isoM]// := faithful_repr_extraspecial_pchar _ _ oPpn _ _ simM.
     apply/eqP; apply: (TI_center_nil (pgroup_nil pP)).
       rewrite /= -(eqmx_rstab _ (val_submod1 M)) -(rstab_submod modM).
       exact: rker_normal.
@@ -744,9 +745,9 @@ have mulBg x: x \in P -> B x *m gE = yr *m B x.
 wlog sH: / irrType F H by apply: socle_exists.
 have{cycH} linH: irr_degree (_ : sH) = 1%N.
   exact: irr_degree_abelian (cyclic_abelian cycH).
-have baseH := linear_irr_comp F'H (closF H) (linH _).
+have baseH := linear_irr_comp_pchar F'H (closF H) (linH _).
 have{} linH (W : sH): \rank W = 1%N by rewrite baseH; apply: linH.
-have [w] := cycle_repr_structure sH defH F'H (closF H).
+have [w] := cycle_repr_structure_pchar sH defH F'H (closF H).
 rewrite -/h => prim_w [Wi [bijWi _ _ Wi_yg]].
 have{Wi_yg baseH} Wi_yr i: Wi i *m yr = w ^+ i *: (Wi i : 'M_h).
   have /submxP[u ->]: (Wi i <= val_submod (irr_repr (Wi i) 1%g))%MS.
@@ -767,7 +768,7 @@ have{bijWi sumB cl1 F'H} defSB: (SB :=: 1%:M)%MS.
   apply/eqmxP; rewrite submx1 -sumB (big_setD1 _ cl1) addsmxS //=.
   rewrite exchange_big sumsmxS // => ZxH _; rewrite genmxE /= -sumsmxMr_gen.
   rewrite -((reindex Wi) xpredT val) /=; first by apply: onW_bij.
-  by rewrite -/(Socle _) (reducible_Socle1 sH (mx_Maschke _ F'H)) mul1mx.
+  by rewrite -/(Socle _) (reducible_Socle1 sH (mx_Maschke_pchar _ F'H)) mul1mx.
 rewrite mxdirect_addsE /= in dxB; case/and3P: dxB => _ dxB dxB1.
 have{linH Bfree dxB} rankB1 i: \rank (B1 i) = #|clPqH^#|.
   rewrite -sum1_card (mxdirectP _) /=; last first.
@@ -826,19 +827,19 @@ Qed.
 (* 2.6(b).                                                                    *)
 Theorem der1_odd_GL2_charf F gT (G : {group gT})
                            (rG : mx_representation F G 2) :
- odd #|G| -> mx_faithful rG -> [char F].-group G^`(1)%g.
+ odd #|G| -> mx_faithful rG -> [pchar F].-group G^`(1)%g.
 Proof.
 move=> oddG ffulG.
 without loss closF: F rG ffulG / group_closure_field F gT.
   move=> IH; apply: (@group_closure_field_exists gT F) => [[Fc f closFc]].
-  rewrite -(eq_pgroup _ (fmorph_char f)).
+  rewrite -(eq_pgroup _ (fmorph_pchar f)).
   by rewrite -(map_mx_faithful f) in ffulG; apply: IH ffulG closFc.
 elim: {G}_.+1 {-2}G (ltnSn #|G|) => // m IHm G le_g_m in rG oddG ffulG *.
 apply/pgroupP=> p p_pr pG'; rewrite !inE p_pr /=; apply: wlog_neg => p_nz.
 have [P sylP] := Sylow_exists p G.
 have nPG: G \subset 'N(P).
   apply/idPn=> ltNG; pose N := 'N_G(P); have sNG: N \subset G := subsetIl _ _.
-  have{IHm ltNG} p'N': [char F].-group N^`(1)%g.
+  have{IHm ltNG} p'N': [pchar F].-group N^`(1)%g.
     apply: IHm (subg_mx_faithful sNG ffulG); last exact: oddSg oddG.
     rewrite -ltnS (leq_trans _ le_g_m) // ltnS proper_card //.
     by rewrite /proper sNG subsetI subxx.
@@ -864,7 +865,7 @@ have pQ: (p %| #|Q|)%N.
   by rewrite part_pnat_id ?part_pnat.
 have{IHm} abelQ: abelian Q.
   apply/commG1P/eqP/idPn => ntQ'.
-  have{IHm} p'Q': [char F].-group Q^`(1)%g.
+  have{IHm} p'Q': [pchar F].-group Q^`(1)%g.
     apply: IHm (subg_mx_faithful sQG ffulG); last exact: oddSg oddG.
     rewrite -ltnS (leq_trans _ le_g_m) // ltnS proper_card //.
     rewrite /proper sQG subsetI //= andbC subEproper.
@@ -882,7 +883,7 @@ wlog [U simU sU1]: / exists2 U, mxsimple rQ U & (U <= 1%:M)%MS.
   by apply: mxsimple_exists; rewrite ?mxmodule1 ?oner_eq0.
 have Uscal: \rank U = 1%N by apply: (mxsimple_abelian_linear (closF _)) simU.
 have{simU} [Umod _ _] := simU.
-have{sU1} [|V Vmod sumUV dxUV] := mx_Maschke _ _ Umod sU1.
+have{sU1} [|V Vmod sumUV dxUV] := mx_Maschke_pchar _ _ Umod sU1.
   have: p.-group Q by apply: pgroupS (pHall_pgroup sylP); rewrite subsetIr.
   by apply: sub_in_pnat=> q _; move/eqnP->; rewrite !inE p_pr.
 have [u defU]: exists u : 'rV_2, (u :=: U)%MS.
@@ -983,7 +984,7 @@ Qed.
 (* This is B & G, Theorem 2.6(a) *)
 Theorem charf'_GL2_abelian F gT (G : {group gT})
                            (rG : mx_representation F G 2) :
-  odd #|G| -> mx_faithful rG -> [char F]^'.-group G -> abelian G.
+  odd #|G| -> mx_faithful rG -> [pchar F]^'.-group G -> abelian G.
 Proof.
 move=> oddG ffG char'G; apply/commG1P/eqP.
 rewrite trivg_card1 (pnat_1 _ (pgroupS _ char'G)) ?comm_subG //=.
@@ -993,12 +994,12 @@ Qed.
 (* This is B & G, Theorem 2.6(b) *)
 Theorem charf_GL2_der_subS_abelian_Sylow p F gT (G : {group gT})
                                          (rG : mx_representation F G 2) :
-    odd #|G| -> mx_faithful rG -> p \in [char F] ->
+    odd #|G| -> mx_faithful rG -> p \in [pchar F] ->
   exists P : {group gT}, [/\ p.-Sylow(G) P, abelian P & G^`(1)%g \subset P].
 Proof.
 move=> oddG ffG charFp.
 have{oddG} pG': p.-group G^`(1)%g.
-  rewrite /pgroup -(eq_pnat _ (charf_eq charFp)).
+  rewrite /pgroup -(eq_pnat _ (pcharf_eq charFp)).
   exact: der1_odd_GL2_charf ffG.
 have{pG'} [P SylP sG'P]:= Sylow_superset (der_sub _ _) pG'.
 exists P; split=> {sG'P}//; case/and3P: SylP => sPG pP _.
@@ -1007,7 +1008,7 @@ apply/subsetP=> _ /imset2P[y z Py Pz ->]; rewrite inE (subsetP sPG) ?groupR //=.
 pose rP := subg_repr rG sPG; pose U := rfix_mx rP P.
 rewrite -(inj_eq (can_inj (mulKmx (repr_mx_unit rP (groupM Pz Py))))).
 rewrite mul1mx mulmx1 -repr_mxM ?(groupR, groupM) // -commgC !repr_mxM //.
-have: U != 0 by apply: (rfix_pgroup_char charFp).
+have: U != 0 by apply: (rfix_pgroup_pchar charFp).
 rewrite -mxrank_eq0 -lt0n 2!leq_eqVlt ltnNge rank_leq_row orbF orbC eq_sym.
 case/orP=> [Ufull | Uscal].
   suffices{y z Py Pz} rP1 y: y \in P -> rP y = 1%:M by rewrite !rP1 ?mulmx1.
@@ -1026,7 +1027,7 @@ pose B := col_mx u v; have uB: B \in unitmx.
 have Umod: mxmodule rP U by apply: rfix_mx_module.
 pose W := rfix_mx (factmod_repr Umod) P.
 have ntW: W != 0.
-  apply: (rfix_pgroup_char charFp) => //.
+  apply: (rfix_pgroup_pchar charFp) => //.
   rewrite eqmxMfull ?row_full_unit ?unitmx_inv ?row_ebase_unit //.
   by rewrite rank_copid_mx -(eqP Uscal).
 have{ntW} Wfull: row_full W.
@@ -1075,8 +1076,8 @@ have ne_qp: q != p.
   move/implyP: (logn_quotient_cent_abelem nPQ abelP).
   by rewrite logP regQ indexg1 /=; case: eqP => // <-; rewrite logQ.
 have redQ: mx_completely_reducible rQ 1%:M.
-  apply: mx_Maschke; apply: pi_pnat (abelem_pgroup abelQ) _.
-  by rewrite inE /= (charf_eq (char_Fp p_pr)).
+  apply: mx_Maschke_pchar; apply: pi_pnat (abelem_pgroup abelQ) _.
+  by rewrite inE /= (pcharf_eq (pchar_Fp p_pr)).
 have [P2 modP2 sumP12 dxP12] := redQ _ modP1 (submx1 _).
 have{dxP12} linP2: \rank P2 = 1%N.
   apply: (@addnI 1%N); rewrite -{1}linP1 -(mxdirectP dxP12) /= sumP12.

--- a/theories/BGsection3.v
+++ b/theories/BGsection3.v
@@ -26,7 +26,8 @@ Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
 Local Open Scope ring_scope.
-Import GroupScope GRing.Theory.
+Local Open Scope group_scope.
+Import GRing.Theory.
 
 Section BGsection3.
 
@@ -106,10 +107,10 @@ End FrobeniusQuotient.
 (* This is B & G, Lemma 3.3. *)
 Lemma Frobenius_rfix_compl F gT (G K R : {group gT}) n
                           (rG : mx_representation F G n) :
-    [Frobenius G = K ><| R] -> [char F]^'.-group K ->
+    [Frobenius G = K ><| R] -> [pchar F]^'.-group K ->
   ~~ (K \subset rker rG) -> rfix_mx rG R != 0.
 Proof.
-rewrite /pgroup charf'_nat => frobG nzK.
+rewrite /pgroup pcharf'_nat => frobG nzK.
 have [defG _ _ ltKG ltRG]:= Frobenius_context frobG.
 have{ltKG ltRG} [sKG sRG]: K \subset G /\ R \subset G by rewrite !proper_sub.
 apply: contraNneq => fixR0; rewrite rfix_mx_rstabC // -(eqmx_scale _ nzK).
@@ -184,7 +185,7 @@ have: rfix_mx (abelem_repr abelH ntH nHR) P == 0.
 apply: contraLR => not_cQP; have{not_cQP} frobR: [Frobenius R = Q ><| P].
   by apply/prime_FrobeniusP; rewrite ?prime_TIg ?oP ?oQ // centsC.
 apply: (Frobenius_rfix_compl frobR).
-  rewrite (eq_p'group _ (charf_eq (char_Fp pr_r))).
+  rewrite (eq_p'group _ (pcharf_eq (pchar_Fp pr_r))).
   rewrite (coprime_p'group _ (abelem_pgroup abelH)) //.
   by rewrite coprime_sym (coprimegS sQR) ?regular_norm_coprime.
 rewrite rker_abelem subsetI sQR centsC.
@@ -195,7 +196,7 @@ Qed.
 Theorem odd_prime_sdprod_rfix0 F gT (G K R : {group gT}) n 
                                (rG : mx_representation F G n) :
     K ><| R = G -> solvable G -> odd #|G| -> coprime #|K| #|R| -> prime #|R| ->
-    [char F]^'.-group G -> rfix_mx rG R = 0 ->
+    [pchar F]^'.-group G -> rfix_mx rG R = 0 ->
   [~: R, K] \subset rker rG.
 Proof.
 move: {2}_.+1 (ltnSn #|G|) => m; elim: m => // m IHm in gT G K R n rG *.
@@ -234,7 +235,7 @@ without loss [q q_pr qK]: / exists2 q, prime q & q.-group K.
   by rewrite !quotient_cents2r ?ker_ltK.
 without loss{m IHm leGm} [ffulG cycZ]: / rker rG = 1 /\ cyclic 'Z(G).
   move=> IH; wlog [I M /= simM sumM _]: / mxsemisimple rG 1%:M.
-    exact: (mx_reducible_semisimple (mxmodule1 _) (mx_Maschke _ F'G)).
+    exact: (mx_reducible_semisimple (mxmodule1 _) (mx_Maschke_pchar _ F'G)).
   pose not_cRK_M i := ~~ ([~: R, K] \subset rstab rG (M i)).
   case: (pickP not_cRK_M) => [i | cRK_M]; last first.
     rewrite rfix_mx_rstabC ?comm_subG // -sumM.
@@ -322,7 +323,7 @@ apply: subset_trans (_ : rker rV \subset _); last first.
   by rewrite rker_abelem subsetIr.
 apply: odd_prime_sdprod_rfix0 => //.
   have k_pr: prime k by case/pgroup_pdiv: (abelem_pgroup abelV).
-  by rewrite (eq_pgroup G (eq_negn (charf_eq (char_Fp k_pr)))).
+  by rewrite (eq_pgroup G (eq_negn (pcharf_eq (pchar_Fp k_pr)))).
 by apply/eqP; rewrite -submx0 rfix_abelem //= regR morphim1 rowg_mx1.
 Qed.
 
@@ -330,14 +331,14 @@ Qed.
 Theorem Frobenius_prime_rfix1 F gT (G K R : {group gT}) n
                               (rG : mx_representation F G n) :
     K ><| R = G -> solvable G -> prime #|R| -> 'C_K(R) = 1 ->
-    [char F]^'.-group G -> \rank (rfix_mx rG R) = 1%N ->
+    [pchar F]^'.-group G -> \rank (rfix_mx rG R) = 1%N ->
   K^`(1) \subset rker rG.
 Proof.
 move=> defG solG p_pr regR F'G fixRlin.
 wlog closF: F rG F'G fixRlin / group_closure_field F gT.
   move=> IH; apply: (@group_closure_field_exists gT F) => [[Fc f closFc]].
   rewrite -(rker_map f) IH //; last by rewrite -map_rfix_mx mxrank_map.
-  by rewrite (eq_p'group _ (fmorph_char f)).
+  by rewrite (eq_p'group _ (fmorph_pchar f)).
 move: {2}_.+1 (ltnSn #|K|) => m.
 elim: m => // m IHm in gT G K R rG solG p_pr regR F'G closF fixRlin defG *.
 rewrite ltnS => leKm.
@@ -407,7 +408,7 @@ have dx_modK_rfix (N : {group gT}) U V:
   have: fixG R != 0 by rewrite -mxrank_eq0 fixRlin.
   apply: contraR; case/norP=> not_fixU not_fixW.
   by rewrite -submx0 -(mxdirect_addsP dxUV) sub_capmx !nfixU.
-have redG := mx_Maschke rG F'G.
+have redG := mx_Maschke_pchar rG F'G.
 wlog [U simU nfixU]: / exists2 U, mxsimple rG U & ~~ (U <= fixG K)%MS.
   move=> IH; wlog [I U /= simU sumU _]: / mxsemisimple rG 1%:M.
     exact: (mx_reducible_semisimple (mxmodule1 _) redG).
@@ -496,7 +497,7 @@ wlog irrG': / mx_irreducible rG'.
   move=> IH; wlog [M simM sM1]: / exists2 M, mxsimple rG' M & (M <= 1%:M)%MS.
     by apply: mxsimple_exists; rewrite ?mxmodule1; case: irrK.
   have [modM ntM _] := simM.
-  have [M' modM' sumM dxM] := mx_Maschke rG' (pgroupS sG'G F'G) modM sM1.
+  have [M' modM' sumM dxM] := mx_Maschke_pchar rG' (pgroupS sG'G F'G) modM sM1.
   wlog{IH} ntM': / M' != 0.
     case: eqP sumM => [-> M1 _ | _ _ -> //]; apply: IH.
     by apply: mx_iso_simple simM; apply: eqmx_iso; rewrite addsmx0_id in M1.
@@ -574,7 +575,7 @@ apply: subset_trans (_ : rker rV \subset _); last first.
   by rewrite rker_abelem subsetIr.
 have k_pr: prime k by case/pgroup_pdiv: (abelem_pgroup abelV).
 apply: (Frobenius_prime_rfix1 defG) => //.
-  by rewrite (eq_pgroup G (eq_negn (charf_eq (char_Fp k_pr)))).
+  by rewrite (eq_pgroup G (eq_negn (pcharf_eq (pchar_Fp k_pr)))).
 apply/eqP; rewrite rfix_abelem // -(eqn_exp2l _ _ (prime_gt1 k_pr)).
 rewrite -{1}(card_Fp k_pr) -card_rowg rowg_mxK.
 by rewrite card_injm ?abelem_rV_injm ?subsetIl ?primeRV.
@@ -943,7 +944,7 @@ have iK'K: 'C_(P <*> R / K')(K / K') = 1 -> #|K / K'| > q ^ 2.
   move: rPR; rewrite (dim_abelemE abelKb ntKb) oKb pfactorK // => rPR ffPR.
   apply: charf'_GL2_abelian ffPR _.
     by rewrite quotient_odd ?(oddSg _ oddG) // join_subG (subset_trans sPH).
-  rewrite (eq_pgroup _ (eq_negn (charf_eq (char_Fp q_pr)))).
+  rewrite (eq_pgroup _ (eq_negn (pcharf_eq (pchar_Fp q_pr)))).
   rewrite quotient_pgroup //= norm_joinEr // pgroupM.
   by rewrite /pgroup (pi_pnat rR) // (pi_pnat pP) // !inE eq_sym.
 case cKK: (abelian K); last first.
@@ -1346,12 +1347,12 @@ case (eqVneq q p) => [def_q | neq_qp].
   have sKGq: K / L \subset G / L by apply: quotientS.
   rewrite rfix_mx_rstabC //; have [_ _]:= irrVq; apply; rewrite ?submx1 //.
     by rewrite normal_rfix_mx_module ?quotient_normal.
-  rewrite -(rfix_subg _ sKGq) (@rfix_pgroup_char _ p) ?char_Fp -?def_q //.
+  rewrite -(rfix_subg _ sKGq) (@rfix_pgroup_pchar _ p) ?pchar_Fp -?def_q //.
   exact: (abelem_pgroup abelKq).
 suffices: rfix_mx rVq (R / L) == 0.
   apply: contraLR; apply: (Frobenius_rfix_compl frobGq).
   apply: pi_pnat (abelem_pgroup abelKq) _.
-  by rewrite inE /= (charf_eq (char_Fp p_pr)).
+  by rewrite inE /= (pcharf_eq (pchar_Fp p_pr)).
 rewrite -mxrank_eq0 (rfix_quo _ _ sRG) (rfix_morphim _ _ sRG).
 rewrite (rfix_abelem _ _ _ (morphimS _ sRG)) mxrank_eq0 rowg_mx_eq0 -subG1.
 rewrite (sub_abelem_rV_im _ _ _ (subsetIl _ _)) -(morphpreSK _ (subsetIl _ _)).

--- a/theories/BGsection4.v
+++ b/theories/BGsection4.v
@@ -19,7 +19,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section Section4.
 
@@ -1109,7 +1109,7 @@ have{defC} <-: rker rV = C; last move: rV.
   rewrite rker_morphim rker_abelem morphpreI morphimK //=.
   by rewrite (trivgP injA) mul1g -astabEsd // defC astab_ract 2!setIA !setIid.
 have ->: 'dim Vb = 2 by rewrite (dim_abelemE abelVb) // card_injm -?rank_abelem.
-move=> rV; rewrite -(eq_pgroup _ (GRing.charf_eq (char_Fp p_pr))).
+move=> rV; rewrite -(eq_pgroup _ (GRing.pcharf_eq (pchar_Fp p_pr))).
 by apply: der1_odd_GL2_charf (kquo_mx_faithful rV); rewrite !morphim_odd.
 Qed.
 

--- a/theories/BGsection5.v
+++ b/theories/BGsection5.v
@@ -36,7 +36,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Reserved Notation "p .-narrow" (format "p .-narrow").
 

--- a/theories/BGsection6.v
+++ b/theories/BGsection6.v
@@ -18,7 +18,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section Six.
 

--- a/theories/BGsection7.v
+++ b/theories/BGsection7.v
@@ -43,7 +43,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Reserved Notation "''M'" (format "''M'").
 Reserved Notation "''M' ( H )" (format "''M' ( H )").

--- a/theories/BGsection8.v
+++ b/theories/BGsection8.v
@@ -18,7 +18,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section Eight.
 

--- a/theories/BGsection9.v
+++ b/theories/BGsection9.v
@@ -19,7 +19,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope.
+Local Open Scope group_scope.
 
 Section Nine.
 

--- a/theories/PFsection1.v
+++ b/theories/PFsection1.v
@@ -22,7 +22,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope Order.TTheory GRing.Theory Num.Theory.
+Import Order.TTheory GRing.Theory Num.Theory.
+Local Open Scope group_scope.
 Local Open Scope ring_scope.
 
 Section Main.
@@ -538,7 +539,7 @@ have ITtheta: T \subset 'I[theta] := subsetIr _ _.
 have solT: solvable (T / H) := abelian_sol abTbar.
 have [|t []] := extend_solvable_coprime_irr nsHT solT ITtheta; last by exists t.
 rewrite coprime_sym coprimeMl !(coprime_dvdl _ hallH) ?cfDet_order_dvdG //.
-by rewrite -dvdC_nat !CdivE truncK ?Cnat_irr1 // dvd_irr1_cardG.
+by rewrite -dvdC_nat !CdivE truncnK ?Cnat_irr1 // dvd_irr1_cardG.
 Qed.
   
 End IndSumInertia.

--- a/theories/PFsection10.v
+++ b/theories/PFsection10.v
@@ -44,7 +44,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope Order.TTheory GRing.Theory Num.Theory.
+Import Order.TTheory GRing.Theory Num.Theory.
+Local Open Scope group_scope.
 
 Section Ten.
 
@@ -186,7 +187,7 @@ by have [[]] := compl_of_typeII maxS StypeP Stype2.
 Qed.
 Let w2_pr := FTtype345_core_prime.
 
-Definition FTtype345_TIirr_degree := Num.trunc (mu2_ 0 #1 1%g).
+Definition FTtype345_TIirr_degree := Num.truncn (mu2_ 0 #1 1%g).
 Definition FTtype345_TIsign := delta_ #1.
 Local Notation d := FTtype345_TIirr_degree.
 Local Notation delta := FTtype345_TIsign.
@@ -206,18 +207,18 @@ have invj j: j != 0 -> mu2_ 0 j 1%g = d%:R /\ delta_ j = delta.
   rewrite -(cforder_dprodr defW) -dprod_IirrEr in co_k_j1.
   have{co_k_j1} [[u Dj1u] _] := cycTIiso_aut_exists ctiWM co_k_j1.
   rewrite dprod_IirrEr -rmorphXn -Dj /= -!dprod_IirrEr -!/(w_ _ _) in Dj1u.
-  rewrite truncK ?Cnat_irr1 //.
+  rewrite truncnK ?Cnat_irr1 //.
   have: delta_ j *: mu2_ 0 j == cfAut u (delta_ #1 *: mu2_ 0 #1).
     by rewrite -!(cycTIiso_prTIirr pddM) -/ctiWM -Dj1u.
   rewrite raddfZsign /= -prTIirr_aut eq_scaled_irr signr_eq0 /= /mu2_.
   by case/andP=> /eqP-> /eqP->; rewrite prTIirr_aut cfunE/= aut_natr ?Cnat_irr1.
 have d_gt1: (d > 1)%N.
-  rewrite ltn_neqAle andbC -eqC_nat -ltC_nat truncK ?Cnat_irr1 //.
+  rewrite ltn_neqAle andbC -eqC_nat -ltC_nat truncnK ?Cnat_irr1 //.
   rewrite irr1_gt0 /= eq_sym; apply: contraNneq nz_j1 => mu2_lin.
   have: mu2_ 0 #1 \is a linear_char by rewrite qualifE/= irr_char /= mu2_lin.
   by rewrite lin_irr_der1 => /(prTIirr0P ptiWM)[i /irr_inj/prTIirr_inj[_ ->]].
 split=> // [i j /invj[<- _] | _ /invj[//] | ]; first by rewrite prTIirr_1.
-have: (d%:R == delta %[mod w1])%C by rewrite truncK ?Cnat_irr1 ?prTIirr1_mod.
+have: (d%:R == delta %[mod w1])%C by rewrite truncnK ?Cnat_irr1 ?prTIirr1_mod.
 rewrite /eqCmod unfold_in -/n (negPf (neq0CG W1)) natrEint => ->.
 rewrite divr_ge0 ?ler0n // [delta]signrE opprB addrA -natrD subr_ge0 ler1n.
 by rewrite -(subnKC d_gt1).
@@ -445,8 +446,8 @@ suffices: n ^+ 2 < n + 1.
   have: (2%N %| n * w1%:R)%C.
     rewrite divfK ?neq0CG // -signrN signrE addrA -(natrD _ d 1).
     by rewrite rpredB // dvdC_nat dvdn2 ?odd_double // oddD d_odd.
-  rewrite -(truncK Nn) -mulrSr -natrM -natrX ltC_nat (dvdC_nat 2) pnatr_eq0.
-  rewrite dvdn2 oddM mFT_odd; case: (Num.trunc n) => [|[|n1]] // _ /idPn[].
+  rewrite -(truncnK Nn) -mulrSr -natrM -natrX ltC_nat (dvdC_nat 2) pnatr_eq0.
+  rewrite dvdn2 oddM mFT_odd; case: (Num.truncn n) => [|[|n1]] // _ /idPn[].
   by rewrite -leqNgt (ltn_exp2l 1).
 apply: lt_le_trans (_ : n * - delta + 1 <= _); last first.
   have ->: n + 1 = n * `|- delta| + 1 by rewrite normrN normr_sign mulr1.

--- a/theories/PFsection11.v
+++ b/theories/PFsection11.v
@@ -27,7 +27,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope Order.TTheory GRing.Theory FinRing.Theory Num.Theory Num.Def.
+Import Order.TTheory GRing.Theory Num.Theory.
+Local Open Scope group_scope.
 
 Section Eleven.
 
@@ -822,7 +823,7 @@ pose j := j1. (* The remainder of the proof only uses j = 1. *)
 have Rbeta: cfReal beta.
   rewrite /cfReal eq_sym -subr_eq0 rmorphD/= !rmorphB/= opprB 2!opprD opprB -/j.
   rewrite 2![(eta_ 0 _)^*%CF]cfAut_cycTIiso -!cycTIirr_aut !aut_Iirr0 -Dade_aut.
-  set k := aut_Iirr conjC j; rewrite -(betaE 0 k) ?aut_Iirr_eq0 // addrACA.
+  set k := aut_Iirr Num.conj j; rewrite -(betaE 0 k) ?aut_Iirr_eq0 // addrACA.
   rewrite addrC addr_eq0 addrCA subrK opprD opprK Dn raddfZnat -!raddfB /= -Dn.
   apply/eqP; rewrite (cfConjC_Dade_coherent coh_tau1) ?mFT_odd // -raddfB.
   rewrite Dtau1 ?Zzeta_S1 ?cfAut_seqInd //= -linearZ scalerBr; congr (tau _).

--- a/theories/PFsection12.v
+++ b/theories/PFsection12.v
@@ -23,7 +23,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope Order.TTheory GRing.Theory FinRing.Theory Num.Theory.
+Import Order.TTheory GRing.Theory FinRing.Theory Num.Theory.
+Local Open Scope group_scope.
 Local Open Scope ring_scope.
 
 Section PFTwelve.
@@ -847,8 +848,8 @@ have defV: V :=: 'Ohm_1(P0).
   by rewrite p_rank_abelian // -card_pgroup ?(pgroupS (Ohm_sub 1 _)).
 pose rE := abelem_repr abelV ntV nVE.
 have ffulE: mx_faithful rE by apply: abelem_mx_faithful.
-have p'E: [char 'F_p]^'.-group E.
-  rewrite (eq_p'group _ (charf_eq (char_Fp pr_p))) (coprime_p'group _ pV) //.
+have p'E: [pchar 'F_p]^'.-group E.
+  rewrite (eq_p'group _ (pcharf_eq (pchar_Fp pr_p))) (coprime_p'group _ pV) //.
   by rewrite coprime_sym (coprimeSg sVH) ?(Frobenius_coprime frobHE).
 have dimV: 'dim V = 2%N by rewrite (dim_abelemE abelV) // oV pfactorK.
 have cEE: abelian E.
@@ -866,10 +867,10 @@ have /trivgPn[y nty Ey]: E != 1%G by have [] := Frobenius_context frobHE.
 have cErEy: centgmx rE (rE y).
   by apply/centgmxP=> z Ez; rewrite -!repr_mxM // (centsP cEE).
 have irrE: mx_irreducible rE by apply/abelem_mx_irrP.
-have charFp2: p \in [char MatrixGenField.gen_of irrE cErEy].
-  apply: (rmorph_char (MatrixGenField.gen irrE cErEy)).
-  exact: char_Fp.
-pose Fp2 : finFieldType := PrimeCharType charFp2.
+have charFp2: p \in [pchar MatrixGenField.gen_of irrE cErEy].
+  apply: (rmorph_pchar (MatrixGenField.gen irrE cErEy)).
+  exact: pchar_Fp.
+pose Fp2 : finFieldType := pPrimeCharType charFp2.
 pose n1 := MatrixGenField.gen_dim (rE y).
 pose rEp2 : mx_representation Fp2 E n1 := MatrixGenField.gen_repr irrE cErEy.
 have n1_gt0: (0 < n1)%N := MatrixGenField.gen_dim_gt0 irrE cErEy.

--- a/theories/PFsection13.v
+++ b/theories/PFsection13.v
@@ -48,7 +48,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope Order.TTheory GRing.Theory FinRing.Theory Num.Theory.
+Import Order.TTheory GRing.Theory Num.Theory.
+Local Open Scope group_scope.
 
 Section Thirteen.
 
@@ -1436,8 +1437,6 @@ move=> gal'S; have: has irrIndH calS.
 by case/hasP=> lambda Slam /FTtypeP_Ind_Fitting_nonGalois_facts; apply.
 Qed.
 
-Import FinRing.Theory.
-
 (* This is Peterfalvi (13.14). *)
 Lemma FTtypeP_primes_mod_cases :
   [/\ odd ustar,
@@ -1479,7 +1478,7 @@ have pq_r: p%:R ^+ q == 1 :> 'F_r.
 have Up_r: (p%:R : 'F_r) \is a GRing.unit.
   by rewrite -(unitrX_pos _ (prime_gt0 pr_q)) (eqP pq_r) unitr1.
 congr (_ %| _): (order_dvdG (in_setT (FinRing.unit 'F_r Up_r))).
-apply/prime_nt_dvdP=> //; last by rewrite order_dvdn -val_eqE val_unitX.
+apply/prime_nt_dvdP=> //; last by rewrite order_dvdn -val_eqE FinRing.val_unitX.
 rewrite -dvdn1 order_dvdn -val_eqE /= -subr_eq0 -val_eqE -(@natrB _ p 1) //=.
 rewrite subn1 val_Fp_nat //; apply: contraFN (esym (mem_primes r 1)).
 by rewrite pr_r /= -(eqnP co_ustar_p1) dvdn_gcd r_dv_ustar.
@@ -2111,9 +2110,9 @@ have{Gamma_even} odd_bSphi_bLeta: (bSphi + bLeta == 1 %[mod 2])%C.
   rewrite 2?(orthogonalP otau1eta _ _ (map_f _ _) (mem_eta _)) // oppr0 !add0r.
   by rewrite addr0 addrA addrC addr_eq0 !opprB addrA /eqCmod => /eqP <-.
 have abs_mod2 a: a \in Num.int -> {b : bool | a == b%:R %[mod 2%N]}%C.
-  move=> Za; pose n := Num.trunc `|a|; exists (odd n).
+  move=> Za; pose n := Num.truncn `|a|; exists (odd n).
   apply: eqCmod_trans (eqCmod_addl_mul _ (rpred_nat _ n./2) _).
-  rewrite addrC -natrM -natrD muln2 odd_double_half truncK ?natr_norm_int //.
+  rewrite addrC -natrM -natrD muln2 odd_double_half truncnK ?natr_norm_int //.
   rewrite -{1}[a]mul1r -(canLR (signrMK _) (intrEsign Za)) eqCmodMr // signrE.
   by rewrite /eqCmod opprB addrC subrK dvdC_nat dvdn2 odd_double.
 have [[bL DbL] [bS DbS]] := (abs_mod2 _ ZbLeta, abs_mod2 _ ZbSphi).

--- a/theories/PFsection14.v
+++ b/theories/PFsection14.v
@@ -28,7 +28,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope Order.TTheory GRing.Theory FinRing.Theory Num.Theory Num.Def.
+Import Order.TTheory GRing.Theory Num.Theory.
+Local Open Scope group_scope.
 
 Section Fourteen.
 
@@ -272,7 +273,7 @@ suffices /cfdot_add_dirr_eq1: '[tau1L phi - tau1L phi^*%CF, chi] = 1.
   by apply; rewrite // dirrE Ztau1 ?Itau1 ?mem_zchar ?irrWnorm /=.
 rewrite cfdotBr (span_orthogonal o_tauLeta) ?add0r //.
   by rewrite rpredB ?memv_span ?map_f ?cfAut_seqInd.
-have Zdphi := seqInd_sub_aut_zchar nsHL conjC Lphi.
+have Zdphi := seqInd_sub_aut_zchar nsHL Num.conj Lphi.
 rewrite -raddfB Dtau1 ?zcharD1_seqInd // Dade_isometry ?(zchar_on Zdphi) //.
 rewrite cfdotBr !cfdotBl cfdot_conjCl cfAutInd rmorph1 irrWnorm //.
 rewrite (seqInd_ortho_Ind1 _ _ Lphi) // conjC0 subrr add0r opprK.

--- a/theories/PFsection2.v
+++ b/theories/PFsection2.v
@@ -47,7 +47,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope GRing.Theory Num.Theory.
+Import GRing.Theory Num.Theory.
+Local Open Scope group_scope.
 Local Open Scope ring_scope.
 
 Reserved Notation "alpha ^\tau" (format "alpha ^\tau").

--- a/theories/PFsection3.v
+++ b/theories/PFsection3.v
@@ -59,7 +59,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope Order.TTheory GRing.Theory Num.Theory.
+Import Order.TTheory GRing.Theory Num.Theory.
+Local Open Scope group_scope.
 Local Open Scope ring_scope.
 
 Section Definitions.

--- a/theories/PFsection4.v
+++ b/theories/PFsection4.v
@@ -64,7 +64,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope Order.TTheory GRing.Theory Num.Theory.
+Import Order.TTheory GRing.Theory Num.Theory.
+Local Open Scope group_scope.
 Local Open Scope ring_scope.
 
 Section Four_1_to_2.
@@ -275,7 +276,7 @@ Definition primeTI_Iirr ij := (primeTIdIirr ij).2.
 Definition primeTI_Isign j := (primeTIdIirr (0, j)).1.
 Local Notation Imu2 := primeTI_Iirr.
 Local Notation mu2_ i j := 'chi_(primeTI_Iirr (i, j)).
-Local Notation delta_ j := (GRing.sign algCring (primeTI_Isign j)).
+Local Notation delta_ j := (GRing.sign algCnzRing (primeTI_Isign j)).
 
 Let ew_ i j := w_ i j - w_ 0 j.
 Let V2ew i j : ew_ i j \in 'CF(W, W :\: W2).
@@ -687,7 +688,7 @@ Qed.
 End Four_3_to_5.
 
 Notation primeTIsign ptiW j :=
-  (GRing.sign algCring (primeTI_Isign ptiW j)) (only parsing).
+  (GRing.sign algCnzRing (primeTI_Isign ptiW j)) (only parsing).
 Notation primeTIirr ptiW i j := 'chi_(primeTI_Iirr ptiW (i, j)) (only parsing).
 Notation primeTIres ptiW j := 'chi_(primeTI_Ires ptiW j) (only parsing).
 

--- a/theories/PFsection5.v
+++ b/theories/PFsection5.v
@@ -50,7 +50,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope Order.TTheory GRing.Theory Num.Theory Num.Def.
+Import Order.TTheory GRing.Theory Num.Theory.
+Local Open Scope group_scope.
 Local Open Scope ring_scope.
 
 (* Results about the set of induced irreducible characters *)
@@ -494,7 +495,7 @@ Definition subcoherent S tau R :=
               orthogonal phi (xi :: xi^*%CF) -> orthogonal (R phi) (R xi)}].
 
 Definition dual_iso (nu : {additive 'CF(L) -> 'CF(G)}) : {additive _ -> _} :=
-  -%R \o nu \o cfAut conjC.
+  -%R \o nu \o cfAut Num.conj.
 
 End Defs.
 
@@ -596,7 +597,7 @@ Proof.
 case=> -[N_S _ _] [Itau Ztau] oSS _ _ Seta1 Zzeta1 isoS Izeta1.
 have freeS := orthogonal_free oSS; have uniqS := free_uniq freeS.
 have{oSS} [/andP[S'0 _] oSS] := pairwise_orthogonalP oSS.
-pose d := eta1 1%g; pose a (eta : 'CF(L)) := Num.trunc (eta 1%g / d).
+pose d := eta1 1%g; pose a (eta : 'CF(L)) := Num.truncn (eta 1%g / d).
 have{S'0} nzd: d != 0 by rewrite char1_eq0 ?N_S ?(memPn S'0).
 pose S1 := eta1 :: [seq eta - eta1 *+ a eta | eta <- rem eta1 S].
 have sS_ZS1: {subset S <= 'Z[S1]}; last apply: (subgen_coherent sS_ZS1).
@@ -613,7 +614,7 @@ have{} isoS: {in behead S1, forall zeta, iso_eta1 zeta}.
   rewrite /iso_eta1 => _ /mapP[eta Seta ->]; rewrite mem_rem_uniq // in Seta.
   have{Seta} [/isoS[q [Nq Dq] Itau_eta1] [eta1'eta Seta]] := (Seta, andP Seta).
   rewrite zcharD1E rpredB ?rpredMn ?mem_zchar //= -scaler_nat /a Dq mulfK //.
-  by rewrite truncK // !cfunE Dq subrr cfdotBl cfdotZl -mulNr oSS ?add0r.
+  by rewrite truncnK // !cfunE Dq subrr cfdotBl cfdotZl -mulNr oSS ?add0r.
 have isoS1: {in S1, isometry [eta tau with eta1 |-> zeta1], to 'Z[irr G]}.
   split=> [xi eta | eta]; rewrite !in_cons /=; last first.
     by case: eqP => [-> | _  /isoS[/Ztau/zcharW]].

--- a/theories/PFsection6.v
+++ b/theories/PFsection6.v
@@ -31,7 +31,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope Order.TTheory GRing.Theory Num.Theory.
+Import Order.TTheory GRing.Theory Num.Theory.
+Local Open Scope group_scope.
 Local Open Scope ring_scope.
 
 (* The main section *)
@@ -288,7 +289,7 @@ rewrite -(isog_pgroup p (quotient1_isog K)) => pK ab'K.
 set e := #|L : K| => not_e_dv_p1; have e_gt0: (e > 0)%N by apply: indexg_gt0.
 have ntK: K != 1%G by apply: contraNneq ab'K => ->; rewrite quotient1 abelian1.
 have{ab'K ntK} [p_pr p_dv_K _] := pgroup_pdiv pK ntK.
-set Y := calX; pose d (xi : 'CF(L)) := logn p (Num.trunc (xi 1%g) %/ e).
+set Y := calX; pose d (xi : 'CF(L)) := logn p (Num.truncn (xi 1%g) %/ e).
 have: cfConjC_closed Y by apply: cfAut_seqInd.
 have: perm_eq (Y ++ [::]) calX by rewrite cats0.
 have: {in Y & [::], forall xi1 xi2, d xi1 <= d xi2}%N by [].
@@ -765,11 +766,11 @@ have{odd_frobL1} caseA_cohXY: caseA -> coherent (X ++ Y) L^# tau.
     rewrite !cfInd1 // !De -!natrM dvdC_nat dvdn_pmul2l //.
     by rewrite dvdn_Pexp2l ?min_i1 ?prime_gt1.
   have nz_xi1_1: xi1 1%g != 0 by apply: seqInd1_neq0 Xxi1.
-  pose d (xi : 'CF(L)) : algC := (Num.trunc (xi 1%g / xi1 1%g))%:R.
+  pose d (xi : 'CF(L)) : algC := (Num.truncn (xi 1%g / xi1 1%g))%:R.
   have{dvd_xi1_1} def_d xi: xi \in X -> xi 1%g = d xi * xi1 1%g.
     rewrite /d => Xxi; have Xge0 := natr_ge0 (Cnat_seqInd1 (_ : _ \in X)).
     by have /dvdCP_nat[||q ->] := dvd_xi1_1 xi Xxi; rewrite ?Xge0 ?mulfK ?natrK.
-  have d_xi1: d xi1 = 1 by rewrite /d divff ?trunc1.
+  have d_xi1: d xi1 = 1 by rewrite /d divff ?truncn1.
   have [_ [Itau /(_ _ _)/zcharW-Ztau] _ _ _] := scohS.
   have o_tauXY: orthogonal (map tau2 X) (map tau1 Y).
     exact: (coherent_ortho scohS).

--- a/theories/PFsection7.v
+++ b/theories/PFsection7.v
@@ -29,7 +29,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope Order.TTheory GRing.Theory Num.Theory.
+Import Order.TTheory GRing.Theory Num.Theory.
+Local Open Scope group_scope.
 Local Open Scope ring_scope.
 
 Reserved Notation "alpha ^\rho" (format "alpha ^\rho").

--- a/theories/PFsection8.v
+++ b/theories/PFsection8.v
@@ -54,8 +54,9 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope GRing.Theory.
+Import GRing.Theory.
 
+Local Open Scope group_scope.
 Local Open Scope ring_scope.
 
 (* Supercedes the notation in BGsection14. *)

--- a/theories/PFsection9.v
+++ b/theories/PFsection9.v
@@ -39,7 +39,8 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Import GroupScope Order.TTheory GRing.Theory FinRing.Theory Num.Theory Num.Def.
+Import Order.TTheory GRing.Theory FinRing.Theory Num.Theory.
+Local Open Scope group_scope.
 
 Section Nine.
 
@@ -555,8 +556,8 @@ have{cEE} [F [outF [inF outFK inFK] E_F]]:
   have mul1F: left_id one mul by move=> a; apply: outI; rewrite outM out1 mul1r.
   have mulD: left_distributive mul +%R%R.
     by move=> a1 a2 b; apply: canLR outK _; rewrite !raddfD mulrDl -!{1}outM.
-  pose rV_isComRing := GRing.Zmodule_isComRing.Build 'rV__ mulA mulC mul1F mulD nzFone.
-  Time pose Fring : comRingType := HB.pack 'rV__ rV_isComRing.
+  pose rV_isComRing := GRing.Zmodule_isComNzRing.Build 'rV__ mulA mulC mul1F mulD nzFone.
+  Time pose Fring : comNzRingType := HB.pack 'rV__ rV_isComRing.
   have outRM: multiplicative (outF : Fring -> _) by [].
   have mulI (nza : {a | a != 0%R :> Fring}): GRing.rreg (val nza).
     case: nza => a /=; rewrite -(inj_eq outI) out0 => nzA b1 b2 /(congr1 outF).
@@ -564,10 +565,10 @@ have{cEE} [F [outF [inF outFK inFK] E_F]]:
     by rewrite row_free_unit (mx_Schur irrU) ?cEE ?E_F.
   pose inv (a : Fring) := oapp (fun nza => invF (mulI nza) one) a (insub a).
   have inv0: (inv 0 = 0)%R by rewrite /inv insubF ?eqxx.
-  pose field_axiom (R : ringType) inv := (forall x : R, x != 0 :>R -> inv x * x = 1 :> R)%R.
+  pose field_axiom (R : nzRingType) inv := (forall x : R, x != 0 :>R -> inv x * x = 1 :> R)%R.
   have mulV: field_axiom _ inv.
     by move=> a nz_a; rewrite /inv insubT /= (f_invF (mulI (exist _ _ _))).
-  pose IsField := GRing.ComRing_isField.Build Fring mulV inv0.
+  pose IsField := GRing.ComNzRing_isField.Build Fring mulV inv0.
   Time pose F : finFieldType := HB.pack Fring IsField.
   pose outaM := GRing.isAdditive.Build Fring _ _ (raddfB outF).
   pose outmM := GRing.isMultiplicative.Build _ _ _ outRM.
@@ -716,8 +717,8 @@ exists F.
       by apply/allP=> r'; rewrite mem_enum.
     apply: contraNneq nz_v => /polyP P0; apply/eqP/rowP=> i; apply/eqP.
     have /eqP := P0 i; rewrite mxE coef0 coef_poly ltn_ord inord_val.
-    have charF: p \in [char F]%R by rewrite !inE p_pr -order_dvdn -o_nF /=.
-    by rewrite -(dvdn_charf charF) (dvdn_charf (char_Fp p_pr)) natr_Zp.
+    have charF: p \in [pchar F]%R by rewrite !inE p_pr -order_dvdn -o_nF /=.
+    by rewrite -(dvdn_pcharf charF) (dvdn_pcharf (pchar_Fp p_pr)) natr_Zp.
   have{Pr0 nP} fPr0 f: autF f -> root P (f r).
     move=> fRM.
     pose faM := GRing.isAdditive.Build _ _ _ fRM.1.
@@ -2060,7 +2061,8 @@ have [S1'lam1 Slam1]: lam1 \notin S1 /\ lam1 \in S_ H0C'.
 have S3lam1s: lam1^*%CF \in S3 by have [[_ _ ->]] := scohS3.
 have ZS3dlam1: lam1 - lam1^*%CF \in 'Z[S3, M^#].
   rewrite zcharD1E rpredB ?mem_zchar //.
-  by have:= seqInd_sub_aut_zchar nsHUM conjC Slam1; rewrite zcharD1 => /andP[].
+  have:= seqInd_sub_aut_zchar nsHUM Num.conj Slam1.
+  by rewrite zcharD1 => /andP[].
 have ZAdlam1: lam1 - lam1^*%CF \in 'Z[irr M, 'A(M)].
   rewrite sS0A // zchar_split rpredB ?mem_zchar ?cfAut_seqInd //.
   by rewrite (zchar_on ZS3dlam1).
@@ -2127,7 +2129,7 @@ have [Gamma [S4_Gamma normGamma [b Dbeta]]]:
     have N_G: '[G] \in Num.nat.
       apply: Cnat_cfnorm_vchar; apply: zchar_sub_irr Z_G => _ /mapP[nu S4nu ->].
       by rewrite Ztau34 ?mem_zchar.
-    rewrite -(truncK N_G) ler1n lt0n -eqC_nat truncK {N_G}// cfnorm_eq0.
+    rewrite -(truncnK N_G) ler1n lt0n -eqC_nat truncnK {N_G}// cfnorm_eq0.
     have: '[beta^\tau, (lam1 - lam1^*%CF)^\tau] != 0.
       rewrite Itau // cfdotBl cfdotZl !cfdotBr n1lam1.
       rewrite (seqInd_conjC_ortho _ _ _ Slam1) ?mFT_odd // subr0.
@@ -2147,7 +2149,7 @@ have [Gamma [S4_Gamma normGamma [b Dbeta]]]:
       congr (_ + _); rewrite dB scaleNr [- _ + _]addrC cfnormB !cfnormZ.
       rewrite normr_nat intr_normK // scaler_sumr cfdotZr rmorph_nat.
       rewrite cfnorm_map_orthonormal // cfproj_sum_orthonormal //.
-      rewrite Itau1 ?mem_zchar// n1psi1 mulr1 [conjC _]rmorphM/= rmorph_nat.
+      rewrite Itau1 ?mem_zchar// n1psi1 mulr1 [Num.conj _]rmorphM/= rmorph_nat.
       rewrite conj_intr // -mulr2n oS1ua -muln_divA // -addrA addrCA mulrBl.
       by rewrite -mulrnAl -mulrnA mul2n muln2 -natrX [b * _]mulrC.
     rewrite Itau // cfnormBd.

--- a/theories/stripped_odd_order_theorem.v
+++ b/theories/stripped_odd_order_theorem.v
@@ -111,7 +111,7 @@ Local Notation Asol := solvable_group.
 Import HB.structures.
 Import Prelude ssreflect ssrbool ssrfun eqtype ssrnat choice fintype finset fingroup.
 Import morphism quotient action gfunctor gproduct commutator gseries nilpotent.
-Import GroupScope.
+Local Open Scope group_scope.
 
 Lemma main T mul one inv G nn :
     group_axioms T mul one inv -> Agroup T mul one inv G ->

--- a/theories/wielandt_fixpoint.v
+++ b/theories/wielandt_fixpoint.v
@@ -22,8 +22,8 @@ Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
 Local Open Scope ring_scope.
-Import GroupScope GRing.Theory.
-Import FinRing.Theory.
+Local Open Scope group_scope.
+Import GRing.Theory FinRing.Theory.
 
 Implicit Types (gT wT : finGroupType) (m n p q : nat).
 
@@ -359,9 +359,9 @@ have sumS: (\sum_(U in S) gMx U :=: 1%:M)%MS.
   have sUL: U \subset L by rewrite -(bigdprodWY defL) sub_gen // (bigcup_max U).
   rewrite inE (subsetP sUL) ?Uc // inE mem_rowg (sumsmx_sup U) // -mem_rowg.
   by rewrite (subsetP (sub_rowg_mx _)) // mem_morphim ?(subsetP sUL) ?Uc.
-have Fp'G: [char 'F_p]^'.-group G.
-  by rewrite (eq_p'group _ (charf_eq (char_Fp p_pr))).
-have [VK [modVK defVK]] := rsim_regular_submod mx_irrV Fp'G.
+have Fp'G: [pchar 'F_p]^'.-group G.
+  by rewrite (eq_p'group _ (pcharf_eq (pchar_Fp p_pr))).
+have [VK [modVK defVK]] := rsim_regular_submod_pchar mx_irrV Fp'G.
 have [U S_U isoUV]: {U | U \in S & mx_iso (regular_repr _ G) (gMx U) VK}.
   apply: hom_mxsemisimple_iso (scalar_mx_hom _ 1 _) _ => [|U S_U _|]; auto.
     by apply/(submod_mx_irr modVK); apply: (mx_rsim_irr defVK).


### PR DESCRIPTION
This should also make Odd Order compatible with math-comp/math-comp#1600 (not tested).